### PR TITLE
[Misc] fix SpecTest.java intermittently timeout

### DIFF
--- a/test/jdk/sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java
+++ b/test/jdk/sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java
@@ -25,7 +25,7 @@
  * @bug 8051408 8157308 8130181
  * @modules java.base/sun.security.provider
  * @build java.base/sun.security.provider.S
- * @run main SpecTest
+ * @run main/othervm -Djava.security.egd=file:/dev/urandom SpecTest
  * @summary check the AbstractDrbg API etc
  */
 


### PR DESCRIPTION
Summary: fix sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java intermittently fail, use /dev/urandom instead of /dev/random to avoid block for SecureRandom API

Test Plan: CI pipeline

Reviewed-by: lvfei.lv, lei.yul

Issue: https://github.com/alibaba/dragonwell17/issues/35