### PR TITLE
[Wisp] Support AArch64 platform.

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3869,8 +3869,15 @@ encode %{
     //
     // Try to CAS m->owner from NULL to current thread.
     __ add(tmp, disp_hdr, (ObjectMonitor::owner_offset_in_bytes()-markWord::monitor_value));
+    if (UseWispMonitor) {
+      __ ldr (rthread, Address(rthread, JavaThread::current_coroutine_offset()));
+      __ ldr (rthread, Address(rthread, Coroutine::wisp_thread_offset()));
+    }
     __ cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
                /*release*/ true, /*weak*/ false, rscratch1); // Sets flags for result
+    if (UseWispMonitor) {
+      __ ldr (rthread, Address(rthread, WispThread::thread_offset()));
+    }
 
     // Store a non-null value into the box to avoid looking like a re-entrant
     // lock. The fast-path monitor unlock code checks for
@@ -3881,7 +3888,14 @@ encode %{
 
     __ br(Assembler::EQ, cont); // CAS success means locking succeeded
 
+    if (UseWispMonitor) {
+      __ ldr (rthread, Address(rthread, JavaThread::current_coroutine_offset()));
+      __ ldr (rthread, Address(rthread, Coroutine::wisp_thread_offset()));
+    }
     __ cmp(rscratch1, rthread);
+    if (UseWispMonitor) {
+      __ ldr (rthread, Address(rthread, WispThread::thread_offset()));
+    }
     __ br(Assembler::NE, cont); // Check for recursive locking
 
     // Recursive lock case
@@ -17095,6 +17109,24 @@ instruct tlsLoadP(thread_RegP dst)
   size(0);
 
   ins_encode( /*empty*/ );
+
+  ins_pipe(pipe_class_empty);
+%}
+
+// Thread refetch:
+// take two main arguments:
+// 1. register @rthread
+// 2. one register which contains the `Coroutine *`
+// and move Coroutine->_thread to @rthread
+instruct tlsRefetchP(thread_RegP dst, iRegP src)
+%{
+  match(Set dst (ThreadRefetch src));
+
+  format %{ "Refetch the rthread register" %}
+
+  ins_encode %{
+  __ ldr(rthread, Address($src$$Register, Coroutine::thread_offset()));
+  %}
 
   ins_pipe(pipe_class_empty);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1245,6 +1245,7 @@ source_hpp %{
 #include "opto/addnode.hpp"
 #include "opto/convertnode.hpp"
 #include "runtime/objectMonitor.hpp"
+#include "runtime/coroutine.hpp"
 
 extern RegMask _ANY_REG32_mask;
 extern RegMask _ANY_REG_mask;

--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -249,8 +249,31 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce) {
   } else {
     exit_id = Runtime1::monitorexit_nofpu_id;
   }
+  // Handle special case for wisp unpark.
+  // The code stub is entered only when the following four conditions are all satisfied
+  // 1. A synchronized method is compiled by C1
+  // 2. An exception happened in this method
+  // 3. There is no exception handler in this method, So it needs to unwind to its caller
+  // 4. GC happened during unpark
+  // if (_info == NULL) is true, the four conditions are all true.
+  if (UseWispMonitor && (_info == NULL)) {
+    if (exit_id == Runtime1::monitorexit_id) {
+      exit_id = Runtime1::monitorexit_proxy_id;
+    } else {
+      assert (exit_id == Runtime1::monitorexit_nofpu_id, "must be monitorexit_nofpu_id");
+      exit_id = Runtime1::monitorexit_nofpu_proxy_id;
+    }
+  }
+  // on X86, despite we will call java, we have no need to generate an oopmap here,
+  // because c1_CodeStubs_x86.cpp only emit a jump here, when GC happens, we won't
+  // see the _last_pc pointing here.
+  // However, on aarch64 here it uses lr to jump from the far_jump stub.
+  // so the _last_pc will be seen by stack unwinding as a single frame,
+  // when GC searches the pc related oopmap, it will crash.
+  // so, because of this implementation we should emit the OopMap where the `continuation` lays.
   __ adr(lr, _continuation);
   __ far_jump(RuntimeAddress(Runtime1::entry_for(exit_id)));
+  __ should_not_reach_here();
 }
 
 

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -436,7 +436,7 @@ int LIR_Assembler::emit_unwind_handler() {
   MonitorExitStub* stub = NULL;
   if (method()->is_synchronized()) {
     monitor_address(0, FrameMap::r0_opr);
-    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0);
+    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0, NULL);
     __ unlock_object(r5, r4, r0, *stub->entry());
     __ bind(*stub->continuation());
   }
@@ -2593,6 +2593,13 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
     Unimplemented();
   }
   __ bind(*op->stub()->continuation());
+  // add an OopMap here.
+  if (UseWispMonitor && op->code() == lir_unlock) {
+    // For direct unpark in Wisp, _info must be recorded to generate the oopmap.
+    guarantee(op->info() != NULL, "aarch64 needs an OopMap because the adr(lr, ...), so pc will be searched for the OopMap");
+    add_call_info_here(op->info());
+    verify_oop_map(op->info());
+  }
 }
 
 

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -341,7 +341,18 @@ void LIRGenerator::do_MonitorExit(MonitorExit* x) {
   LIR_Opr lock = new_register(T_INT);
   LIR_Opr obj_temp = new_register(T_INT);
   set_no_result(x);
-  monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
+  // Info is used to generate the oopmap, which is necessary for calling java code during runtime.
+  if (UseWispMonitor) {
+    CodeEmitInfo* info = NULL;
+    if (x->state()) {
+      info = state_for(x, x->state(), true);
+    }
+    // add info_for_exception CodeInfo here.
+    CodeEmitInfo* info_for_exception = state_for(x, x->state(), true);
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no(), info_for_exception, info);
+  } else {
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
+  }
 }
 
 

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -42,6 +42,7 @@
 #include "oops/oop.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "register_aarch64.hpp"
+#include "runtime/coroutine.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stubRoutines.hpp"

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -50,6 +50,8 @@
 #include "utilities/powerOfTwo.hpp"
 #include "vmreg_aarch64.inline.hpp"
 
+// the Runtime1::monitorenter function pointer
+extern address monitorenter_address_C1;
 
 // Implementation of StubAssembler
 
@@ -71,6 +73,18 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   blr(rscratch1);
   bind(retaddr);
   int call_offset = offset();
+
+  // the call_offset is the pc for the call()'s return rip so that it should be
+  // inserted directly after the call.
+  // the call_offset is used for something like 'frame::sender_for_compiled_frame'
+  // in order to use the call_offset as the pc address to find the OopMap address
+  if (EnableCoroutine) {
+    // only if the entry_point is equal to `Runtime1::monitorenter()` will we do this amendment.
+    if (entry == monitorenter_address_C1) {
+      WISP_V2v_UPDATE;
+    }
+  }
+
   // verify callee-saved register
 #ifdef ASSERT
   push(r0, sp);
@@ -956,6 +970,11 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers(sasm, save_fpu_registers);
+
+        if (EnableCoroutine) {
+          // rthread has been forcibly restored in restore_live_registers so we need to fix it.
+          WISP_COMPILER_RESTORE_FORCE_UPDATE;
+        }
       }
       break;
 
@@ -974,7 +993,34 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         // note: really a leaf routine but must setup last java sp
         //       => use call_RT for now (speed can be improved by
         //       doing last java sp setup manually)
-        int call_offset = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit), r0);
+        int call_offset = 0;
+        if (UseWispMonitor) {
+          call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit_wisp), r0);
+        } else {
+          call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit), r0);
+        }
+        oop_maps = new OopMapSet();
+        oop_maps->add_gc_map(call_offset, map);
+        restore_live_registers(sasm, save_fpu_registers);
+      }
+      break;
+    case monitorexit_nofpu_proxy_id:
+      save_fpu_registers = false;
+    // fall through
+    case monitorexit_proxy_id:
+      {
+        StubFrame f(sasm, "monitorexit", dont_gc_arguments);
+        OopMap* map = save_live_registers(sasm, save_fpu_registers);
+
+        // Called with store_parameter and not C abi
+        f.load_argument(0, r0); // r0,: lock address
+        int call_offset = 0;
+        if (UseWispMonitor) {
+          call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit_wisp_proxy), r0);
+        } else {
+          call_offset = 0;
+          __ should_not_reach_here();
+        }
 
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);

--- a/src/hotspot/cpu/aarch64/coroutine_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/coroutine_aarch64.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "prims/privilegedStack.hpp"
+#include "runtime/coroutine.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/jniHandles.inline.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitor.inline.hpp"
+#include "services/threadService.hpp"
+
+#include CPU_HEADER(coroutine)
+#include CPU_HEADER_INLINE(vmreg)
+
+void Coroutine::set_coroutine_base(intptr_t **&base, JavaThread* thread, jobject obj, Coroutine *coro, oop coroutineObj, address coroutine_start) {
+  *(--base) = (intptr_t*)obj;
+  *(--base) = (intptr_t*)coro;
+  *(--base) = NULL;
+  *(--base) = (intptr_t*)coroutine_start;
+  *(--base) = NULL;
+  // we need one more pointer space compared to x86:
+  // see `create_switchTo_contents()`, which will push both `lr` and `rfp` onto the stack.
+  // rfp will be saved to this space, which will be the end of gc backtrace.
+  *(--base) = NULL;
+}
+
+Register CoroutineStack::get_fp_reg() {
+  return rfp;
+}
+

--- a/src/hotspot/cpu/aarch64/coroutine_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/coroutine_aarch64.cpp
@@ -21,7 +21,8 @@
  */
 
 #include "precompiled.hpp"
-#include "prims/privilegedStack.hpp"
+#include "asm/assembler.hpp"
+#include "code/vmreg.hpp"
 #include "runtime/coroutine.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/interfaceSupport.inline.hpp"

--- a/src/hotspot/cpu/aarch64/coroutine_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/coroutine_aarch64.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef CPU_AARCH64_VM_COROUTINE_AARCH64_HPP
+#define CPU_AARCH64_VM_COROUTINE_AARCH64_HPP
+
+#define R_TH rthread
+// the below `thread` lays on the stack: something like
+// `const Address thread(rfp, thread_off * wordSize);`
+#define WISP_j2v_UPDATE __ str(R_TH, thread)
+
+#endif // CPU_AARCH64_VM_COROUTINE_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -434,14 +434,27 @@ void InterpreterMacroAssembler::jump_from_interpreted(Register method, Register 
 
   if (JvmtiExport::can_post_interpreter_events()) {
     Label run_compiled_code;
+    Label coroutine_skip_interpret;
     // JVMTI events, such as single-stepping, are implemented partly by avoiding running
     // compiled code in threads for which the event is enabled.  Check here for
     // interp_only_mode if these events CAN be enabled.
     ldrw(rscratch1, Address(rthread, JavaThread::interp_only_mode_offset()));
     cbzw(rscratch1, run_compiled_code);
+    if (EnableCoroutine) {
+      ldrh(rscratch1, Address(method, Method::intrinsic_id_offset_in_bytes()));
+      cmp(rscratch1, vmIntrinsics::_switchTo);
+      br(Assembler::EQ, coroutine_skip_interpret);
+      cmp(rscratch1, vmIntrinsics::_switchToAndExit);
+      br(Assembler::EQ, coroutine_skip_interpret);
+      cmp(rscratch1, vmIntrinsics::_switchToAndTerminate);
+      br(Assembler::EQ, coroutine_skip_interpret);
+    }
     ldr(rscratch1, Address(method, Method::interpreter_entry_offset()));
     br(rscratch1);
     bind(run_compiled_code);
+    if (EnableCoroutine) {
+      bind(coroutine_skip_interpret);
+    }
   }
 
   ldr(rscratch1, Address(method, Method::from_interpreted_offset()));

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -442,11 +442,11 @@ void InterpreterMacroAssembler::jump_from_interpreted(Register method, Register 
     cbzw(rscratch1, run_compiled_code);
     if (EnableCoroutine) {
       ldrh(rscratch1, Address(method, Method::intrinsic_id_offset_in_bytes()));
-      cmp(rscratch1, vmIntrinsics::_switchTo);
+      subs(zr, rscratch1, static_cast<int>(vmIntrinsics::_switchTo));
       br(Assembler::EQ, coroutine_skip_interpret);
-      cmp(rscratch1, vmIntrinsics::_switchToAndExit);
+      subs(zr, rscratch1, static_cast<int>(vmIntrinsics::_switchToAndExit));
       br(Assembler::EQ, coroutine_skip_interpret);
-      cmp(rscratch1, vmIntrinsics::_switchToAndTerminate);
+      subs(zr, rscratch1, static_cast<int>(vmIntrinsics::_switchToAndTerminate));
       br(Assembler::EQ, coroutine_skip_interpret);
     }
     ldr(rscratch1, Address(method, Method::interpreter_entry_offset()));

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1330,7 +1330,15 @@ void MacroAssembler::clinit_barrier(Register klass, Register scratch, Label* L_f
 
   // Fast path check: current thread is initializer thread
   ldr(scratch, Address(klass, InstanceKlass::init_thread_offset()));
+
+  if (UseWispMonitor) {
+    ldr(rthread, Address(rthread, JavaThread::current_coroutine_offset()));
+    ldr(rthread, Address(rthread, Coroutine::wisp_thread_offset()));
+  }
   cmp(rthread, scratch);
+  if (UseWispMonitor) {
+    ldr(rthread, Address(rthread, WispThread::thread_offset()));
+  }
 
   if (L_slow_path == &L_fallthrough) {
     br(Assembler::EQ, *L_fast_path);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -655,6 +655,8 @@ static void pass_arg3(MacroAssembler* masm, Register arg) {
   }
 }
 
+extern address monitorenter_address_interp;
+
 void MacroAssembler::call_VM_base(Register oop_result,
                                   Register java_thread,
                                   Register last_java_sp,
@@ -699,6 +701,13 @@ void MacroAssembler::call_VM_base(Register oop_result,
   // if it was tail-call optimized by compiler, since lr is not callee-saved
   // reload it with proper value
   adr(lr, l);
+
+  if (EnableCoroutine) {
+    // only if the entry_point is equal to `Interpreter::monitorenter()` will we do this amendment.
+    if (entry_point == monitorenter_address_interp) {
+      WISP_V2v_UPDATE;
+    }
+  }
 
   // reset last Java frame
   // Only interpreter should have to clear fp
@@ -963,6 +972,16 @@ void MacroAssembler::get_vm_result(Register oop_result, Register java_thread) {
 void MacroAssembler::get_vm_result_2(Register metadata_result, Register java_thread) {
   ldr(metadata_result, Address(java_thread, JavaThread::vm_result_2_offset()));
   str(zr, Address(java_thread, JavaThread::vm_result_2_offset()));
+}
+
+void MacroAssembler::get_vm_result_for_wisp(Register oop_result, Register java_thread) {
+  assert(EnableCoroutine, "Coroutine is disabled");
+  ldr(oop_result, Address(java_thread, JavaThread::vm_result_for_wisp_offset()));
+  str(zr, Address(java_thread, JavaThread::vm_result_for_wisp_offset()));
+  // In default flow, after calling get_vm_result, vm_result is set to null.
+  // In wisp flow, we should also clear vm_result.
+  str(zr, Address(java_thread, JavaThread::vm_result_offset()));
+  verify_oop(oop_result, "broken oop in call_VM_base");
 }
 
 void MacroAssembler::align(int modulus) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -763,6 +763,7 @@ public:
 
   void get_vm_result  (Register oop_result, Register thread);
   void get_vm_result_2(Register metadata_result, Register thread);
+  void get_vm_result_for_wisp(Register oop_result, Register thread);
 
   // These always tightly bind to MacroAssembler::call_VM_base
   // bypassing the virtual implementation

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -3173,7 +3173,7 @@ void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_ma
   Register thread = rthread;
   Register target_coroutine = j_rarg1;
   // check that we're dealing with sane objects...
-  __ ldr(target_coroutine, Address(target_coroutine, java_dyn_CoroutineBase::get_data_offset()));
+  __ ldr(target_coroutine, Address(target_coroutine, java_dyn_CoroutineBase::get_native_coroutine_offset()));
 
   Register temp = r4;
   Register temp2 = r5;
@@ -3188,7 +3188,7 @@ void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_ma
     Register old_stack = r6;
 
     // check that we're dealing with sane objects...
-    __ ldr(old_coroutine, Address(old_coroutine_obj, java_dyn_CoroutineBase::get_data_offset()));
+    __ ldr(old_coroutine, Address(old_coroutine_obj, java_dyn_CoroutineBase::get_native_coroutine_offset()));
 
     __ movw(temp, Coroutine::_onstack);
     __ strw(temp, Address(old_coroutine, Coroutine::state_offset()));

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -61,6 +61,10 @@
 #include "jvmci/jvmciJavaClasses.hpp"
 #endif
 
+#include "runtime/coroutine.hpp"
+
+void coroutine_start(Coroutine* coroutine, jobject coroutineObj);
+
 #define __ masm->
 
 const int StackAlignmentInSlots = StackAlignmentInBytes / VMRegImpl::stack_slot_size;
@@ -1266,6 +1270,22 @@ static void gen_special_dispatch(MacroAssembler* masm,
                                                  receiver_reg, member_reg, /*for_compiler_entry:*/ true);
 }
 
+void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_maps, int &stack_slots, int total_in_args, BasicType *in_sig_bt, VMRegPair *in_regs, BasicType ret_type, bool terminate);
+
+void generate_thread_fix(MacroAssembler *masm, Method *method) {
+  // we can have a check here at the codegen time, so no cost in runtime.
+  if (EnableCoroutine) {
+    if (WispStealCandidate(method->method_holder()->name(), method->name(), method->signature()).is_steal_candidate()) {
+      // as aarch64 calling conventions, the thread register r28 is one of the callee saved registers.
+      // r19~r28 are callee-saved-registers. See StubRoutines::generate_call_stub()'s callee-saved-register restoration.
+      // the r28 register will be saved at method entry and restored implicitly at method exit
+      // so we have to fix it manually after the method returns.
+      // REF: https://developer.arm.com/docs/den0024/latest/the-abi-for-arm-64-bit-architecture/register-use-in-the-aarch64-procedure-call-standard/parameters-in-general-purpose-registers
+      WISP_CALLING_CONVENTION_V2J_UPDATE;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Generate a native wrapper for a given method.  The method takes arguments
 // in the Java compiled code convention, marshals them to the native
@@ -1532,6 +1552,16 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Generate stack overflow check
   __ bang_stack_with_offset(checked_cast<int>(StackOverflow::stack_shadow_zone_size()));
+
+  if (EnableCoroutine) {
+    // the coroutine support methods have a hand-coded fast version that will handle the most common cases
+    if (method->intrinsic_id() == vmIntrinsics::_switchTo) {
+      create_switchTo_contents(masm, start, oop_maps, stack_slots, total_in_args, in_sig_bt, in_regs, ret_type, false);
+    } else if (method->intrinsic_id() == vmIntrinsics::_switchToAndTerminate ||
+               method->intrinsic_id() == vmIntrinsics::_switchToAndExit) {
+      create_switchTo_contents(masm, start, oop_maps, stack_slots, total_in_args, in_sig_bt, in_regs, ret_type, true);
+    }
+  }
 
   // Generate a new frame for the wrapper.
   __ enter();
@@ -1820,6 +1850,13 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   if (!is_critical_native) {
     __ lea(c_rarg0, Address(rthread, in_bytes(JavaThread::jni_environment_offset())));
 
+    if (EnableCoroutine) {
+      __ ldr(rscratch2, Address(rthread, JavaThread::coroutine_list_offset()));
+      __ lea(rscratch2, Address(rscratch2, Coroutine::native_call_counter_offset()));
+      // we couldn't use rscratch1 because `incrementw` will use rscratch1
+      __ incrementw(Address(rscratch2));
+    }
+
     // Now set thread in native
     __ mov(rscratch1, _thread_in_native);
     __ lea(rscratch2, Address(rthread, JavaThread::thread_state_offset()));
@@ -1827,6 +1864,10 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   rt_call(masm, native_func);
+  // In wisp, this coroutine may be stolen by another thread inside the `native_func` call.
+  // If this `native_func` is one of the several native functions we supported,
+  // we will add thread fix code for them.
+  generate_thread_fix(masm, method());
 
   __ bind(native_return);
 
@@ -1994,6 +2035,25 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ cbnz(rscratch1, exception_pending);
   }
 
+  // Return
+  if (EnableCoroutine &&
+      (method->intrinsic_id() == vmIntrinsics::_switchToAndTerminate ||
+       method->intrinsic_id() == vmIntrinsics::_switchToAndExit)) {
+
+    Label normal;
+    __ lea(rscratch1, RuntimeAddress((unsigned char*)coroutine_start));
+    __ ldr(rscratch2, Address(sp, 0));
+    __ cmp(rscratch2, rscratch1);
+    __ br(Assembler::NE, normal);
+
+    __ ldr(c_rarg0, Address(sp, HeapWordSize * 2));
+    __ ldr(c_rarg1, Address(sp, HeapWordSize * 3));
+
+    __ bind(normal);
+
+    __ ret(lr);        // <-- this will jump to the stored IP of the target coroutine
+  }
+
   // We're done
   __ ret(lr);
 
@@ -2026,6 +2086,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Not a leaf but we have last_Java_frame setup as we want
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_locking_C), 3);
     restore_args(masm, total_c_args, c_arg, out_regs);
+
+    if (EnableCoroutine) {
+      // the rthread has been restored in restore_args so we need to fix it.
+      WISP_COMPILER_RESTORE_FORCE_UPDATE;
+    }
 
 #ifdef ASSERT
     { Label L;
@@ -3092,6 +3157,206 @@ void OptoRuntime::generate_exception_blob() {
 
   // Set exception blob
   _exception_blob =  ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
+}
+
+void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_maps, int &stack_slots, int total_in_args,
+                              BasicType *in_sig_bt, VMRegPair *in_regs, BasicType ret_type, bool terminate) {
+  assert(total_in_args == 2, "wrong number of arguments");
+
+  // unlike x86, something like TemplateTable::prepare_invoke() will
+  // generate the return ip into lr register instead of pushing
+  // on to the stack in x86.
+
+  // push the ip and frame pointer onto the stack
+  __ push(RegSet::of(lr, rfp), sp);
+
+  Register thread = rthread;
+  Register target_coroutine = j_rarg1;
+  // check that we're dealing with sane objects...
+  __ ldr(target_coroutine, Address(target_coroutine, java_dyn_CoroutineBase::get_data_offset()));
+
+  Register temp = r4;
+  Register temp2 = r5;
+  {
+    //////////////////////////////////////////////////////////////////////////
+    // store information into the old coroutine's object
+    //
+    // valid registers: rsi = old Coroutine, rdx = target Coroutine
+
+    Register old_coroutine_obj = j_rarg0;
+    Register old_coroutine = r5;
+    Register old_stack = r6;
+
+    // check that we're dealing with sane objects...
+    __ ldr(old_coroutine, Address(old_coroutine_obj, java_dyn_CoroutineBase::get_data_offset()));
+
+    __ movw(temp, Coroutine::_onstack);
+    __ strw(temp, Address(old_coroutine, Coroutine::state_offset()));
+
+    // rescue old handle and resource areas
+    __ ldr(temp, Address(thread, Thread::handle_area_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::handle_area_offset()));
+    __ ldr(temp, Address(thread, Thread::resource_area_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::resource_area_offset()));
+    __ ldr(temp, Address(thread, Thread::last_handle_mark_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::last_handle_mark_offset()));
+    __ ldr(temp, Address(thread, Thread::active_handles_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::active_handles_offset()));
+    __ ldr(temp, Address(thread, Thread::metadata_handles_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::metadata_handles_offset()));
+    __ ldr(temp, Address(thread, JavaThread::last_Java_pc_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::last_Java_pc_offset()));
+    __ ldr(temp, Address(thread, JavaThread::last_Java_sp_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::last_Java_sp_offset()));
+    __ ldr(temp, Address(thread, JavaThread::threadObj_offset()));
+    __ ldr(temp, Address(temp, 0));
+    __ ldrw(temp, Address(temp, java_lang_Thread::thread_status_offset()));
+    __ strw(temp, Address(old_coroutine, Coroutine::thread_status_offset()));
+    __ ldrw(temp, Address(thread, JavaThread::java_call_counter_offset()));
+    __ strw(temp, Address(old_coroutine, Coroutine::java_call_counter_offset()));
+    __ mov(temp, sp);
+    __ ldr(old_stack, Address(old_coroutine, Coroutine::stack_offset()));
+    __ str(temp, Address(old_stack, CoroutineStack::last_sp_offset())); // str cannot use sp as an argument
+
+    // store StackOverflowState to old coroutine stack
+    __ ldrw(temp, Address(thread, JavaThread::stack_guard_state_offset()));
+    __ strw(temp, Address(old_stack, CoroutineStack::stack_guard_state_offset()));
+    __ ldr(temp, Address(thread, JavaThread::stack_base_offset()));
+    __ str(temp, Address(old_stack, CoroutineStack::stack_base_offset()));
+    __ ldr(temp, Address(thread, JavaThread::stack_end_offset()));
+    __ str(temp, Address(old_stack, CoroutineStack::stack_end_offset()));
+    __ ldr(temp, Address(thread, JavaThread::stack_overflow_limit_offset()));
+    __ str(temp, Address(old_stack, CoroutineStack::stack_overflow_limit_offset()));
+    __ ldr(temp, Address(thread, JavaThread::reserved_stack_activation_offset()));
+    __ str(temp, Address(old_stack, CoroutineStack::reserved_stack_activation_offset()));
+    __ ldrw(temp, Address(thread, Thread::stack_size_offset()));
+    __ strw(temp, Address(old_stack, CoroutineStack::stack_size_offset()));
+  }
+  Register target_stack = rheapbase;
+  __ ldr(target_stack, Address(target_coroutine, Coroutine::stack_offset()));
+
+  {
+    //////////////////////////////////////////////////////////////////////////
+    // perform the switch to the new stack
+    //
+    // valid registers: rdx = target Coroutine
+
+    __ movw(temp, Coroutine::_current);
+    __ strw(temp, Address(target_coroutine, Coroutine::state_offset()));
+    {
+      Register thread = rthread;
+      __ str(target_coroutine, Address(thread, JavaThread::current_coroutine_offset()));
+      // set new handle and resource areas
+      __ ldr(temp, Address(target_coroutine, Coroutine::handle_area_offset()));
+      __ str(temp, Address(thread, Thread::handle_area_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::resource_area_offset()));
+      __ str(temp, Address(thread, Thread::resource_area_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::last_handle_mark_offset()));
+      __ str(temp, Address(thread, Thread::last_handle_mark_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::active_handles_offset()));
+      __ str(temp, Address(thread, Thread::active_handles_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::metadata_handles_offset()));
+      __ str(temp, Address(thread, Thread::metadata_handles_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::last_Java_pc_offset()));
+      __ str(temp, Address(thread, JavaThread::last_Java_pc_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::last_Java_sp_offset()));
+      __ str(temp, Address(thread, JavaThread::last_Java_sp_offset()));
+      __ ldrw(temp2, Address(target_coroutine, Coroutine::thread_status_offset()));
+      __ ldr(temp, Address(thread, JavaThread::threadObj_offset()));
+      __ ldr(temp, Address(temp, 0));
+      __ strw(temp2, Address(temp, java_lang_Thread::thread_status_offset()));
+      __ ldrw(temp, Address(target_coroutine, Coroutine::java_call_counter_offset()));
+      __ strw(temp, Address(thread, JavaThread::java_call_counter_offset()));
+#ifdef ASSERT
+      __ str(zr, Address(target_coroutine, Coroutine::handle_area_offset()));
+      __ str(zr, Address(target_coroutine, Coroutine::resource_area_offset()));
+      __ str(zr, Address(target_coroutine, Coroutine::last_handle_mark_offset()));
+      __ strw(zr, Address(target_coroutine, Coroutine::java_call_counter_offset()));
+#endif
+
+      // update the thread's stack base and size
+      __ ldrw(temp, Address(target_stack, CoroutineStack::stack_guard_state_offset()));
+      __ strw(temp, Address(thread, JavaThread::stack_guard_state_offset()));
+      __ ldr(temp, Address(target_stack, CoroutineStack::stack_base_offset()));
+      __ str(temp, Address(thread, Thread::stack_base_offset()));
+      __ str(temp, Address(thread, JavaThread::stack_base_offset()));
+      __ ldr(temp, Address(target_stack, CoroutineStack::stack_end_offset()));
+      __ str(temp, Address(thread, JavaThread::stack_end_offset()));
+      __ ldr(temp, Address(target_stack, CoroutineStack::stack_overflow_limit_offset()));
+      __ str(temp, Address(thread, JavaThread::stack_overflow_limit_offset()));
+      __ ldr(temp, Address(target_stack, CoroutineStack::reserved_stack_activation_offset()));
+      __ str(temp, Address(thread, JavaThread::reserved_stack_activation_offset()));
+      __ ldrw(temp2, Address(target_stack, CoroutineStack::stack_size_offset()));
+      __ strw(temp2, Address(thread, JavaThread::stack_size_offset()));
+
+      // update JavaThread::_reserved_stack_activation for @ReservedStackAccess support
+      __ str(temp, Address(thread, JavaThread::reserved_stack_activation_offset()));
+    }
+    // restore the stack pointer
+    __ ldr(temp, Address(target_stack, CoroutineStack::last_sp_offset()));
+
+    __ mov(sp, temp);
+
+    __ pop(RegSet::of(lr, rfp), sp);
+
+    if (!terminate) {
+      //////////////////////////////////////////////////////////////////////////
+      // normal case (resume immediately)
+
+      // this will reset r27
+      __ reinit_heapbase();
+
+#ifdef ASSERT
+      {
+        // bomb: clear all temp regs which are used in create_switchTo_contents()
+        __ mov(r0, zr);
+        __ mov(r1, zr);
+        __ mov(r2, zr);
+        __ mov(r3, zr);
+        __ mov(r4, zr);
+        __ mov(r5, zr);
+        __ mov(r6, zr);
+      }
+#endif
+
+      Label normal;
+      __ lea(rscratch1, RuntimeAddress((unsigned char*)coroutine_start));
+      __ ldr(rscratch2, Address(sp, 0));
+      __ cmp(rscratch2, rscratch1);
+      __ br(Assembler::NE, normal);
+
+      // set up the anchor: return address
+      // lr is 0 now, which is popped from stack settled by create_coroutine()
+      __ mov(lr, rscratch1);
+      // set up the coroutine_start() arguments
+      __ ldr(c_rarg0, Address(sp, HeapWordSize * 2));
+      __ ldr(c_rarg1, Address(sp, HeapWordSize * 3));
+
+      __ bind(normal);
+
+      // if the target coroutine is not the first time running (start from coroutine_start)
+      // it will jump directly to
+      // <interpreter>
+      //  TemplateInterpreterGenerator::generate_return_entry_for() stub after unsafeSymmetricYieldTo(),
+      //  and then load the args thru explicit generated bytecodes aload_0 of `this` and aload_N of other args.
+      // <compiler>
+      //  unsafeSymmetricYieldTo()'s nmethod which is compiled by C1/C2. Because bytecodes aload_0 and aload_N
+      //  is generated by javac, so argument registers will be saved on stack before unsafeSymmetricYieldTo()
+      //  and restored back after it.
+      // So it's safe to bzero all registers we used here.
+
+      __ ret(lr);        // <-- this will jump to the stored IP of the target coroutine
+
+    } else {
+      //////////////////////////////////////////////////////////////////////////
+      // slow case (terminate old coroutine)
+
+      // this will reset r27
+      __ reinit_heapbase();
+
+      __ movptr(j_rarg1, 0);
+    }
+  }
 }
 
 // ---------------------------------------------------------------

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -41,6 +41,7 @@
 #include "oops/oop.inline.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/coroutine.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/sharedRuntime.hpp"

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -332,6 +332,15 @@ class StubGenerator: public StubCodeGenerator {
     // pop parameters
     __ sub(esp, rfp, -sp_after_call_off * wordSize);
 
+    if (EnableCoroutine) {
+      Label L;    // the steal thread patch
+      __ ldr(rscratch1, thread);
+      __ cmp(rthread, rscratch1);
+      __ br(Assembler::EQ, L);
+      WISP_j2v_UPDATE;
+      __ bind(L);
+    }
+
 #ifdef ASSERT
     // verify that threads correspond
     {
@@ -406,6 +415,11 @@ class StubGenerator: public StubCodeGenerator {
     // same as in generate_call_stub():
     const Address sp_after_call(rfp, sp_after_call_off * wordSize);
     const Address thread        (rfp, thread_off         * wordSize);
+
+    if (EnableCoroutine) {
+      // to pass the assertion fail
+      WISP_j2v_UPDATE;
+    }
 
 #ifdef ASSERT
     // verify that threads correspond

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -43,6 +43,7 @@
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/coroutine.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/jniHandles.hpp"

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1294,6 +1294,12 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   }
 #endif
 
+  if (EnableCoroutine) {
+    __ ldr(t, Address(rthread, JavaThread::coroutine_list_offset()));
+    __ lea(t, Address(t, Coroutine::native_call_counter_offset()));
+    __ incrementw(Address(t));
+  }
+
   // Change state to native
   __ mov(rscratch1, _thread_in_native);
   __ lea(rscratch2, Address(rthread, JavaThread::thread_state_offset()));
@@ -1304,6 +1310,13 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   __ bind(native_return);
   __ get_method(rmethod);
   // result potentially in r0 or v0
+
+  // when we get back from native c++ code, our coroutine may be stolen by another thread.
+  if (EnableCoroutine) {
+    // it is a little hard to present method signature check here: because interpreter
+    // will directly jump into this entry, which is in runtime.
+    WISP_CALLING_CONVENTION_V2j_UPDATE;
+  }
 
   // make room for the pushes we're about to do
   __ sub(rscratch1, esp, 4 * wordSize);
@@ -1846,11 +1859,31 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 
   // preserve exception over this code sequence
   __ pop_ptr(r0);
-  __ str(r0, Address(rthread, JavaThread::vm_result_offset()));
+  if (EnableCoroutine && UseWispMonitor) {
+    /**
+     * this fix is added here due to the fact that this function may call back to java(at _monitorexit when UseWispMonitor is enabled)
+     * Generally, _monitorexit is invoked by: 1. _return bytecode 2. when exception happens, 3. normally unlock an object.
+     * 1 and 2 will call remove_activation to force unwinding current stack and go up to the caller.
+     * When exception happens, the program will run to: _remove_activation_entry and then remove_activation.
+     * they will both get here while facing race condition.
+     * Only when 2 happens, hotspot will save the exception oop into r0, then call remove_activation.
+     * But because remove_activation possibly use r0, it hence saves r0 (exception oop) to thread->_vm_result temporarily.
+     * It won't see the problem in the normal case because _monitorexit won't call to java(the original vm code impl. does get chance to modify _vm_result)
+     * Because of the call back to java required by Wisp impl. at _monitorexit which in turn may modify _vm_result,
+     * The current fix MUST to restore the exception oop into different field(_vm_result_for_wisp ).
+     */
+    __ str(r0, Address(rthread, JavaThread::vm_result_for_wisp_offset()));
+  } else {
+    __ str(r0, Address(rthread, JavaThread::vm_result_offset()));
+  }
   // remove the activation (without doing throws on illegalMonitorExceptions)
   __ remove_activation(vtos, false, true, false);
   // restore exception
-  __ get_vm_result(r0, rthread);
+  if (EnableCoroutine && UseWispMonitor) {
+    __ get_vm_result_for_wisp(r0, rthread);
+  } else {
+    __ get_vm_result(r0, rthread);
+  }
 
   // In between activations - previous activation type unknown yet
   // compute continuation point - the continuation point expects the

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -213,7 +213,6 @@ CodeBlob* Runtime1::generate_blob(BufferBlob* buffer_blob, int stub_id, const ch
   assert(oop_maps == NULL || sasm->frame_size() != no_frame_size,
          "if stub has an oop map it must have a valid frame size");
   assert(!expect_oop_map || oop_maps != NULL, "must have an oopmap");
-
   // align so printing shows nop's instead of random code at the end (SimpleStubs are aligned)
   sasm->align(BytesPerWord);
   // make sure all code is in code buffer

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3790,27 +3790,6 @@ static void apply_debugger_ergo() {
   }
 }
 
-#ifdef AARCH64
-
-#define UNSUPPORTED_AARCH64_OPTS(opt) \
-   if ((opt)) { \
-      tty->print_cr("Option %s is not supported on AARCH64, VM will exit", #opt); \
-      vm_abort(false); \
-   }
-
-// Some AJDK features are not supported in aarch64
-void Arguments::check_arguments_for_aarch64() {
-  UNSUPPORTED_AARCH64_OPTS(UseVectorAPI);
-  UNSUPPORTED_AARCH64_OPTS(UseAppAOT || !PromoteAOTtoFullProfile);
-  UNSUPPORTED_AARCH64_OPTS(MultiTenant);
-  UNSUPPORTED_AARCH64_OPTS(TenantDataIsolation);
-  UNSUPPORTED_AARCH64_OPTS(TenantThreadStop);
-  UNSUPPORTED_AARCH64_OPTS(TenantCpuThrottling);
-  UNSUPPORTED_AARCH64_OPTS(PrintThreadCoroutineInfo);
-  UNSUPPORTED_AARCH64_OPTS(EagerAppCDS);
-}
-#endif // AARCH64
-
 // Parse entry point called from JNI_CreateJavaVM
 
 jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3790,6 +3790,27 @@ static void apply_debugger_ergo() {
   }
 }
 
+#ifdef AARCH64
+
+#define UNSUPPORTED_AARCH64_OPTS(opt) \
+   if ((opt)) { \
+      tty->print_cr("Option %s is not supported on AARCH64, VM will exit", #opt); \
+      vm_abort(false); \
+   }
+
+// Some AJDK features are not supported in aarch64
+void Arguments::check_arguments_for_aarch64() {
+  UNSUPPORTED_AARCH64_OPTS(UseVectorAPI);
+  UNSUPPORTED_AARCH64_OPTS(UseAppAOT || !PromoteAOTtoFullProfile);
+  UNSUPPORTED_AARCH64_OPTS(MultiTenant);
+  UNSUPPORTED_AARCH64_OPTS(TenantDataIsolation);
+  UNSUPPORTED_AARCH64_OPTS(TenantThreadStop);
+  UNSUPPORTED_AARCH64_OPTS(TenantCpuThrottling);
+  UNSUPPORTED_AARCH64_OPTS(PrintThreadCoroutineInfo);
+  UNSUPPORTED_AARCH64_OPTS(EagerAppCDS);
+}
+#endif // AARCH64
+
 // Parse entry point called from JNI_CreateJavaVM
 
 jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {

--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -38,15 +38,9 @@
 #include "runtime/thread.inline.hpp"
 #include "runtime/vframe.hpp"
 #include "services/threadService.hpp"
-#ifdef TARGET_ARCH_x86
-# include "vmreg_x86.inline.hpp"
-#endif
-#ifdef TARGET_ARCH_sparc
-# include "vmreg_sparc.inline.hpp"
-#endif
-#ifdef TARGET_ARCH_zero
-# include "vmreg_zero.inline.hpp"
-#endif
+
+#include CPU_HEADER(coroutine)
+#include CPU_HEADER_INLINE(vmreg)
 
 
 #ifdef _WINDOWS
@@ -157,12 +151,7 @@ Coroutine* Coroutine::create_coroutine(JavaThread* thread, CoroutineStack* stack
   jobject obj = JNIHandles::make_global(Handle(thread, coroutineObj));
 
   intptr_t** d = (intptr_t**)stack->stack_base();
-#ifdef X86
   set_coroutine_base(d, thread, obj, coro, coroutineObj, (address)coroutine_start);
-#else
-  // TODO: fix this on aarch64
-  guarantee(false, "Wisp is not supported on this arch");
-#endif // X86
 
   stack->set_last_sp((address) d);
 
@@ -481,12 +470,7 @@ void CoroutineStack::frames_do(FrameClosure* fc) {
 #endif
 
   StackFrameStream fst(_thread, fr, true /* update */, true /* process_frames */);
-#ifdef X86
   fst.register_map()->set_location(get_fp_reg()->as_VMReg(), (address)_last_sp);
-#else
-  // TODO: fix this on aarch64
-  guarantee(false, "Wisp is not supported on this arch");
-#endif // X86
   fst.register_map()->set_include_argument_oops(false);
   for(; !fst.is_done(); fst.next()) {
     fc->frames_do(fst.current(), fst.register_map());
@@ -500,12 +484,7 @@ frame CoroutineStack::last_frame(Coroutine* coro, RegisterMap& map) const {
   address pc = ((address*)_last_sp)[1];
   intptr_t* sp = ((intptr_t*)_last_sp) + 2;
 
-#ifdef X86
   map.set_location(get_fp_reg()->as_VMReg(), (address)_last_sp);
-#else
-  // TODO: fix this on aarch64
-  guarantee(false, "Wisp is not supported on this arch");
-#endif // X86
   map.set_include_argument_oops(false);
 
   frame f(sp, fp, pc);

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -258,6 +258,9 @@ public:
   static ByteSize last_SEH_offset()           { return byte_offset_of(Coroutine, _last_SEH); }
 #endif
   static ByteSize wisp_thread_offset()        { return byte_offset_of(Coroutine, _wisp_thread); }
+
+    void set_coroutine_base(int **base, JavaThread *thread, jobject obj, Coroutine *coro, oop coroutineObj,
+                            address coroutine_start);
 };
 
 class CoroutineStack: public CHeapObj<mtThread>, public DoublyLinkedList<CoroutineStack> {
@@ -545,9 +548,7 @@ public:
 //    V: VM frame (C/C++)
 //    v: Other frames running VM generated code (e.g. stubs, adapters, etc.)
 //    C: C/C++ frame
-#ifdef X86
 #include CPU_HEADER(coroutine)
-#endif
 #define WISP_THREAD_UPDATE get_thread(R_TH)
 #define WISP_CALLING_CONVENTION_V2J_UPDATE __ WISP_THREAD_UPDATE
 #define WISP_CALLING_CONVENTION_V2j_UPDATE __ WISP_THREAD_UPDATE

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -108,9 +108,26 @@ public class ServerSocket implements java.io.Closeable {
      * @since 12
      */
     protected ServerSocket(SocketImpl impl) {
+        this(impl, false);
+    }
+
+    /**
+     * Creates a server socket with a user-specified {@code SocketImpl}.
+     *
+     * @param      impl an instance of a SocketImpl to use on the ServerSocket.
+     * @param      dummy tells whether impl is dummy.
+     *
+     * @throws     NullPointerException if impl is {@code null}.
+     *
+     * @throws     SecurityException if a security manager is set and
+     *             its {@code checkPermission} method doesn't allow
+     *             {@code NetPermission("setSocketImpl")}.
+     * @since 12
+     */
+    protected ServerSocket(SocketImpl impl, boolean dummy) {
         Objects.requireNonNull(impl);
         checkPermission();
-        if (WispEngine.transparentWispSwitch()) {
+        if (WispEngine.transparentWispSwitch() && !dummy) {
             throw new UnsupportedOperationException();
         }
         this.impl = impl;

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketAdaptor.java
@@ -72,7 +72,7 @@ class ServerSocketAdaptor                        // package-private
     }
 
     private ServerSocketAdaptor(ServerSocketChannelImpl ssc) {
-        super(DummySocketImpl.create());
+        super(DummySocketImpl.create(), true);
         this.ssc = ssc;
     }
 

--- a/test/jdk/com/alibaba/wisp/TestIo.java
+++ b/test/jdk/com/alibaba/wisp/TestIo.java
@@ -15,8 +15,26 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.util.Properties;
 
 public class TestIo {
+
+    static Properties p;
+    static String socketAddr;
+    static {
+        p = java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<Properties>() {
+                    public Properties run() {
+                        return System.getProperties();
+                    }
+                }
+        );
+        socketAddr = (String)p.get("test.wisp.socketAddress");
+        if (socketAddr == null) {
+            socketAddr = "www.example.com";
+        }
+    }
+
     public static void main(String[] args) {
         String result = http();
 
@@ -29,7 +47,7 @@ public class TestIo {
     }
 
     static String http() {
-        String host = "www.example.com";
+        String host = socketAddr;
 
         try {
             SocketChannel ch = SocketChannel.open();

--- a/test/jdk/com/alibaba/wisp/bug/TestWispSocketLeakWhenConnectTimeout.java
+++ b/test/jdk/com/alibaba/wisp/bug/TestWispSocketLeakWhenConnectTimeout.java
@@ -9,15 +9,33 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.util.Properties;
 
 import static jdk.test.lib.Asserts.assertTrue;
 
 public class TestWispSocketLeakWhenConnectTimeout {
+
+    static Properties p;
+    static String socketAddr;
+    static {
+        p = java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<Properties>() {
+                    public Properties run() {
+                        return System.getProperties();
+                    }
+                }
+        );
+        socketAddr = (String)p.get("test.wisp.socketAddress");
+        if (socketAddr == null) {
+            socketAddr = "www.example.com";
+        }
+    }
+
     public static void main(String[] args) throws IOException {
         Socket so = new Socket();
         boolean timeout = false;
         try {
-            so.connect(new InetSocketAddress("www.facebook.com", 80), 5);
+            so.connect(new InetSocketAddress(socketAddr, 80), 5);
         } catch (SocketTimeoutException e) {
             assertTrue(so.isClosed());
             timeout = true;

--- a/test/jdk/com/alibaba/wisp/io/TestGlobalPoller.java
+++ b/test/jdk/com/alibaba/wisp/io/TestGlobalPoller.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import java.net.Socket;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.util.Properties;
 
 import static jdk.test.lib.Asserts.assertTrue;
 import static jdk.test.lib.Asserts.assertNotNull;
@@ -25,10 +26,26 @@ import static jdk.test.lib.Asserts.assertNotNull;
 public class TestGlobalPoller {
     private static WispEngineAccess access = SharedSecrets.getWispEngineAccess();
 
+    static Properties p;
+    static String socketAddr;
+    static {
+        p = java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<Properties>() {
+                    public Properties run() {
+                        return System.getProperties();
+                    }
+                }
+        );
+        socketAddr = (String)p.get("test.wisp.socketAddress");
+        if (socketAddr == null) {
+            socketAddr = "www.example.com";
+        }
+    }
+
     public static void main(String[] args) throws Exception {
 
 
-        Socket so = new Socket("www.example.com", 80);
+        Socket so = new Socket(socketAddr, 80);
         so.getOutputStream().write("NOP\n\r\n\r".getBytes());
         // now server returns the data..
         // so is readable

--- a/test/jdk/com/alibaba/wisp2/TestHandOff.java
+++ b/test/jdk/com/alibaba/wisp2/TestHandOff.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
 import java.nio.ByteBuffer;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -18,6 +19,23 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static jdk.test.lib.Asserts.assertTrue;
 
 public class TestHandOff {
+
+    static Properties p;
+    static String socketAddr;
+    static {
+        p = java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<Properties>() {
+                    public Properties run() {
+                        return System.getProperties();
+                    }
+                }
+        );
+        socketAddr = (String)p.get("test.wisp.socketAddress");
+        if (socketAddr == null) {
+            socketAddr = "www.example.com";
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         CountDownLatch cl = new CountDownLatch(10);
         for (int i = 0; i < 10; i++) {
@@ -35,7 +53,7 @@ public class TestHandOff {
 
         WispEngine.dispatch(() -> {
             try {
-                SocketChannel ch = SocketChannel.open(new InetSocketAddress("www.example.com", 80));
+                SocketChannel ch = SocketChannel.open(new InetSocketAddress(socketAddr, 80));
                 ch.read(ByteBuffer.allocate(4096));
                 blockingFinish.set(true);
             } catch (IOException e) {

--- a/test/jdk/com/alibaba/wisp2/bug/TestIsInNative.java
+++ b/test/jdk/com/alibaba/wisp2/bug/TestIsInNative.java
@@ -12,15 +12,33 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
+import java.util.Properties;
 
 import static jdk.test.lib.Asserts.assertFalse;
 import static jdk.test.lib.Asserts.assertTrue;
 
 public class TestIsInNative {
+
+    static Properties p;
+    static String socketAddr;
+    static {
+        p = java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<Properties>() {
+                    public Properties run() {
+                        return System.getProperties();
+                    }
+                }
+        );
+        socketAddr = (String)p.get("test.wisp.socketAddress");
+        if (socketAddr == null) {
+            socketAddr = "www.example.com";
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         Thread nthread = new Thread(() -> {
             try {
-                SocketChannel ch = SocketChannel.open(new InetSocketAddress("www.example.com", 80));
+                SocketChannel ch = SocketChannel.open(new InetSocketAddress(socketAddr, 80));
                 ch.read(ByteBuffer.allocate(4096));
             } catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Summary: Support AArch64 platform for Wisp
1. Port JKU coroutine switch logic
2. Port monitor exit support for Wisp monitor
3. Port platform related coroutine work steal support
related patches:
https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/2634264
https://code.aone.alibaba-inc.com/xcode/jdk8u_hotspot/codereview/2634883

Test Plan: all wisp tests on AArch64 platform

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/125