### PR TITLE
[Wisp] Maintain consistency with AJDK8 for WispCounterMXBean, port RCM and wisp patches and fix bugs.

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -817,7 +817,7 @@ class vmSymbols: AllStatic {
   }
 
   enum {
-    log2_SID_LIMIT = 11         // checked by an assert at start-up
+    log2_SID_LIMIT = 12 // checked by an assert at start-up
   };
 
  private:

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1855,7 +1855,7 @@ void ObjectSynchronizer::log_in_use_monitor_details(outputStream* out) {
 }
 
 void SystemDictObjMonitor::lock(BasicLock* lock, Thread* current) {
-  assert(UseWispMonitor, "SystemDictObjMonitor if only for UseWispMonitor");
+  assert(UseWispMonitor, "SystemDictObjMonitor is only for UseWispMonitor");
   if (!current->is_Java_thread()) {
     _monitor->lock();
     return;
@@ -1877,7 +1877,7 @@ void SystemDictObjMonitor::lock(BasicLock* lock, Thread* current) {
 }
 
 void SystemDictObjMonitor::unlock(BasicLock* lock, Thread* current) {
-  assert(UseWispMonitor, "SystemDictObjMonitor if only for UseWispMonitor");
+  assert(UseWispMonitor, "SystemDictObjMonitor is only for UseWispMonitor");
   if (!current->is_Java_thread()) {
     _monitor->unlock();
     return;
@@ -1892,7 +1892,7 @@ void SystemDictObjMonitor::unlock(BasicLock* lock, Thread* current) {
 }
 
 void SystemDictObjMonitor::wait(BasicLock* lock, Thread* current) {
-  assert(UseWispMonitor, "SystemDictObjMonitor if only for UseWispMonitor");
+  assert(UseWispMonitor, "SystemDictObjMonitor is only for UseWispMonitor");
   assert(current->is_Java_thread(), "SystemDictObjMonitor::wait is only for JavaThread");
 
   JavaThread* jt = current->as_Java_thread();
@@ -1903,12 +1903,14 @@ void SystemDictObjMonitor::wait(BasicLock* lock, Thread* current) {
       ObjectSynchronizer::enter(Handle(jt, _obj.resolve()), lock, jt);
     }
   } else {
-    ObjectSynchronizer::wait(Handle(jt, _obj.resolve()), 0, jt);
+    // The purpose of using wait_uninterruptibly is to keep
+    // the behavior consistent with Monitor::wait
+    ObjectSynchronizer::wait_uninterruptibly(Handle(jt, _obj.resolve()), jt);
   }
 }
 
 void SystemDictObjMonitor::notify_all(Thread* current) {
-  assert(UseWispMonitor, "SystemDictObjMonitor if only for UseWispMonitor");
+  assert(UseWispMonitor, "SystemDictObjMonitor is only for UseWispMonitor");
   assert(current->is_Java_thread(), "SystemDictObjMonitor::notify_all is only for JavaThread");
 
   JavaThread* jt = current->as_Java_thread();

--- a/src/java.base/share/classes/com/alibaba/rcm/Constraint.java
+++ b/src/java.base/share/classes/com/alibaba/rcm/Constraint.java
@@ -1,0 +1,62 @@
+package com.alibaba.rcm;
+
+import java.util.Arrays;
+
+/**
+ * A {@code Constraint} is a pair of {@link ResourceType} and {@code values}.
+ * The constrained resource and specification of parameter values are documented
+ * in enum constants in {@link ResourceType}
+ * <p>
+ * A {@code Constraint} must be associated with one {@code ResourceType}, so we
+ * provide factory method {@link ResourceType#newConstraint(long...)} to implement
+ * this restriction. For example:
+ * <pre>
+ *   Constraint cpuConstraint = ResourceType.CPU_PERCENT.newConstraint(30);
+ * </pre>
+ * <p>
+ * {@code ResourceContainer} and  {@code Constraint} follow the one-to-many relationship.
+ * {@link ResourceContainer#getConstraints()} can fetch the Constraint associated with
+ * ResourceContainer.
+ */
+public class Constraint {
+    private final ResourceType type;
+    private final long[] values;
+
+    /**
+     * Constraint should be instantiated by {@link ResourceType#newConstraint(long...)}
+     */
+    protected Constraint(ResourceType type, long[] values) {
+        this.type = type;
+        this.values = values;
+    }
+
+    /**
+     * Returns the currently restricted resource type.
+     *
+     * @return resource type
+     */
+    public ResourceType getResourceType() {
+        return type;
+    }
+
+    /**
+     * Returns the constraint value of ResourceType described by a long[],
+     * which is documented on the ResourceType enums.
+     * <p>
+     * The returned value is a copy of the internal storage array to prevent
+     * modification.
+     *
+     * @return constraint values
+     */
+    public long[] getValues() {
+        return Arrays.copyOf(values, values.length);
+    }
+
+    @Override
+    public String toString() {
+        return "Constraint{" +
+                "type=" + type +
+                ", values=" + Arrays.toString(values) +
+                '}';
+    }
+}

--- a/src/java.base/share/classes/com/alibaba/rcm/ResourceContainer.java
+++ b/src/java.base/share/classes/com/alibaba/rcm/ResourceContainer.java
@@ -1,0 +1,188 @@
+package com.alibaba.rcm;
+
+import com.alibaba.rcm.internal.AbstractResourceContainer;
+
+/**
+ * A {@code ResourceContainer} defines a set of resource {@link Constraint}s
+ * that limit resource usage by threads.
+ * Zero or more threads can be attached to one {@code ResourceContainer}.
+ * <pre>
+ * +-------------------------------+  +-----------------------------+
+ * |ResourceContainer              |  |RootContainer                |
+ * |                               |  |                             |
+ * | +---------------+             |  |                             |
+ * | |CPU Constraint |             |  |        +----------+         |
+ * | +---------------+      <------------------+  Thread  |         |
+ * | +---------------+             |  |        +----------+         |
+ * | |Mem Constraint |command.run()|  | container.run(command)      |
+ * | +---------------+      |      |  |                             |
+ * |    |---------------->  v      |  |                             |
+ * |  resources are   command.run()|  |                             |
+ * |  controlled by   returns      |  |           back to root      |
+ * |  constraints            +----------------->  container         |
+ * |                               |  |                             |
+ * |                               |  |                             |
+ * +-------------------------------+  +-----------------------------+
+ * </pre>
+ * The figure above describes the structure and usage of {@code ResourceContainer}.
+ * <p>
+ * The main Thread is bounded to root container which can be fetched by
+ * {@link ResourceContainer#root()}. Root Container is the system default
+ * {@code ResourceContainer} without any resource restrictions.
+ * Newly created threads are implicitly bounded to {@code ResourceContainer}
+ * of the parent thread.
+ * <p>
+ * A Thread can invoke {@link ResourceContainer#run(Runnable command)} to
+ * attach to the {@code ResourceContainer} and run the {@code command},
+ * the resource usage of the thread is controlled by the {@code ResourceContainer}'s
+ * constraints while running the command.
+ * When the execution of the command is either finished normally
+ * or terminated by Exception, the thread will be detached from the container automatically.
+ * <p>
+ * Components of a {@code ResourceContainer} implementation:
+ * <ul>
+ *     <li>{@link ResourceType}: an implementation can customize some ResourceType</li>
+ *     <li>{@code ResourceContainer}: Implements a class extends
+ *     {@link AbstractResourceContainer}</li>
+ *     <li>{@link ResourceContainerFactory}: service provider </li>
+ * </ul>
+ *
+ * <p>
+ * {@code ResourceContainer} needs to be created from a set of {@code Constraint}s
+ * <p>
+ * In most cases, the following idiom should be used:
+ *  <pre>
+ *    ResourceContainer resourceContainer = containerFactory.createContainer(
+ *      Arrays.asList(
+ *          CPU_PERCENT.newConstraint(50),
+ *          HEAP_RETAINED.newConstraint(100_000_000)
+ *    ));
+ *
+ *    resourceContainer.run(requestHandler);
+ *
+ *    resourceContainer.destroy();
+ *  </pre>
+ *
+ * @see ResourceContainerFactory
+ */
+public interface ResourceContainer {
+    /**
+     * An enumeration of Container state
+     */
+    enum State {
+        /**
+         * Created but not ready for attaching (initializing).
+         */
+        CREATED,
+        /**
+         * Ready for attaching.
+         */
+        RUNNING,
+        /**
+         * {@link ResourceContainer#destroy()} has been called.
+         */
+        STOPPING,
+        /**
+         * Container is destroyed. Further usage is not allowed.
+         */
+        DEAD
+    }
+
+    /**
+     * Returns the system-wide "root" Resource container.
+     * <p>
+     * Root ResourceContainer is a <em>virtual<em/> container that indicates
+     * the default resource container for any thread, which is not attached
+     * to a ResourceContainer created by users. Root ResourceContainer does
+     * not have any resource constrains.
+     * <p>
+     * {@link #run(Runnable)} method of root container is a special
+     * implementation that detaches from the current container and returns
+     * to the root container.
+     * It is very useful in ResourceContainer switch scenario:
+     * <pre>
+     * // Assume we already attach to a non-root resourceContainer1
+     * resourceContainer2.run(command);
+     * // throws exception, because it is illegal to switch between non-root
+     * // ResourceContainers
+     * ResourceContainer.root(() -> resourceContainer2.run(command));
+     * </pre>
+     *
+     * @return root container
+     */
+    static ResourceContainer root() {
+        return AbstractResourceContainer.root();
+    }
+
+    /**
+     * Returns the ResourceContainer associated with the current thread.
+     * For threads that do not attach to any user-created ResourceContainer,
+     * {@link #root()} is returned.
+     *
+     * @return current ResourceContainer
+     */
+    static ResourceContainer current() {
+        return AbstractResourceContainer.current();
+    }
+
+    /**
+     * Returns the current ResourceContainer state.
+     *
+     * @return current state.
+     */
+    ResourceContainer.State getState();
+
+    /**
+     * Attach the current thread to the ResourceContainer to run the {@code command},
+     * and detach the ResourceContainer when {@code command} is either normally finished
+     * or terminated by Exception.
+     * <p>
+     * At the same time, it is not allowed to switch directly between any two
+     * containers. If the switch is indeed required, the
+     * {@link #root()} container should be used.
+     * <p>
+     * This way restricts the container attach/detach mode for the API users,
+     * but is less error-prone.
+     *
+     * <pre>
+     *     ResourceContainer resourceContainer = ....
+     *     assert ResourceContainer.current() == ResourceContainer.root();
+     *     resourceContainer.run(() -> {
+     *         assert ResourceContainer.current() == resourceContainer;
+     *     });
+     *     assert ResourceContainer.current() == ResourceContainer.root();
+     * </pre>
+     *
+     * @param command the target code
+     */
+    void run(Runnable command);
+
+    /**
+     * Updates {@link Constraint} of this resource container.
+     * <p>
+     * Constraints with an identical type will
+     * replace each other according to the calling order.
+     *
+     * @param constraint constraints list
+     * @throws UnsupportedOperationException {@link Constraint#getResourceType()} is not
+     *                                       supported by the implementation
+     */
+    void updateConstraint(Constraint constraint);
+
+    /**
+     * Gets container's {@link Constraint}s
+     *
+     * @return {@code Constraint}s
+     */
+    Iterable<Constraint> getConstraints();
+
+    /**
+     * Destroys this resource container, also kills the attached threads and releases
+     * resources described in {@link #getConstraints()}.
+     * <p>
+     * Once this method is called, the state will become {@link State#STOPPING}.
+     * And the caller thread will be blocked until all the resources have been released.
+     * Then the container state will become {@link State#DEAD}.
+     */
+    void destroy();
+}

--- a/src/java.base/share/classes/com/alibaba/rcm/ResourceContainerFactory.java
+++ b/src/java.base/share/classes/com/alibaba/rcm/ResourceContainerFactory.java
@@ -1,0 +1,31 @@
+package com.alibaba.rcm;
+
+/**
+ * Factory class for {@link ResourceContainer}.
+ * <p>
+ * Each ResourceContainer implementation needs to provide a public
+ * ResourceContainerFactory instance to allow users to choose a specific
+ * ResourceContainer implementation:
+ *
+ * <pre>
+ * ResourceContainerFactory FACTORY_INSTANCE = new ResourceContainerFactory() {
+ *     protected ResourceContainer createContainer(Iterable<Constraint> constraints) {
+ *         return new AbstractResourceContainer() {
+ *             // implement abstract methods
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * Then API users can create ResourceContainer by
+ * {@code FACTORY_INSTANCE.createContainer(...)}
+ */
+public interface ResourceContainerFactory {
+    /**
+     * Builds ResourceContainer with constraints.
+     *
+     * @param constraints the target {@code Constraint}s
+     * @return a newly-created ResourceContainer
+     */
+    ResourceContainer createContainer(Iterable<Constraint> constraints);
+}

--- a/src/java.base/share/classes/com/alibaba/rcm/ResourceType.java
+++ b/src/java.base/share/classes/com/alibaba/rcm/ResourceType.java
@@ -1,0 +1,105 @@
+package com.alibaba.rcm;
+
+/**
+ * Enumeration of {@link Constraint}'s type.
+ * <p>
+ * {@code class} is used instead of {@code enum} to provide extensibility.
+ * Implementation of resource management can define its resource type.
+ * Below is an example of extension ResourceType:
+ *
+ * <pre>
+ *     public class MyResourceType extends ResourceType {
+ *         public final static ResourceType CPU_CFS = new MyResourceType();
+ *
+ *         public MyResourceType() {}
+ *     }
+ * </pre>
+ * <p>
+ * CPU_CFS is an instance of {@code ResourceType}, so it can be used wherever
+ * ResourceType is handled.
+ * <p>
+ * The descriptions and parameters of each public final static value need to
+ * be documented in detail.
+ */
+public class ResourceType {
+    /**
+     * Throttling the CPU usage by CPU percentage.
+     * <p>
+     * param #1: CPU usage measured in a percentage granularity.
+     * The value ranges from 0 to CPU_COUNT * 100. For example, {@code 150}
+     * means that ResourceContainer can use up to 1.5 CPU cores.
+     */
+    public final static ResourceType CPU_PERCENT = new ResourceType("CPU_PERCENT") {
+        @Override
+        protected void validate(long... values) throws IllegalArgumentException {
+            if (values == null || values.length != 1
+                    || values[0] < 1
+                    || values[0] > Runtime.getRuntime().availableProcessors() * 100) {
+                throw new IllegalArgumentException("Bad CPU_PERCENT constraint: " + values[0]);
+            }
+        }
+    };
+
+    /**
+     * Throttling the max heap usage.
+     * <p>
+     * param #1: maximum heap size in bytes
+     */
+    public final static ResourceType HEAP_RETAINED = new ResourceType("HEAP_RETAINED") {
+        @Override
+        protected void validate(long... values) throws IllegalArgumentException {
+            if (values == null || values.length != 1
+                    || values[0] <= 0
+                    || values[0] > Runtime.getRuntime().maxMemory()) {
+                throw new IllegalArgumentException("Bad HEAP_RETAINED constraint: " + values[0]);
+            }
+        }
+    };
+
+    // name of this ResourceType
+    private final String name;
+
+    protected ResourceType(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Creates a {@link Constraint} with this {@code ResourceType} and
+     * the given {@code values}.
+     *
+     * @param values constraint values
+     * @return newly-created Constraint
+     * @throws IllegalArgumentException when parameter check fails
+     */
+    public Constraint newConstraint(long... values) {
+        validate(values);
+        return new Constraint(this, values);
+    }
+
+    /**
+     * Checks the validity of parameters. Since a long [] is used to
+     * express the configuration, a length and range check is required.
+     * <p>
+     * Each ResourceType instance can implement its own {@code validate()}
+     * method through Override, for example:
+     * <pre>
+     * public final static ResourceType MY_RESOURCE =
+     *     new ResourceType() {
+     *         protected void validate(long[] values) throws IllegalArgumentException {
+     *              // the check logic
+     *         }
+     *     };
+     * </pre>
+     *
+     * @param values parameter value
+     * @throws IllegalArgumentException if validation failed
+     */
+    protected void validate(long... values) throws IllegalArgumentException {
+        // No check at all!
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceType-" + name;
+    }
+}

--- a/src/java.base/share/classes/com/alibaba/rcm/internal/AbstractResourceContainer.java
+++ b/src/java.base/share/classes/com/alibaba/rcm/internal/AbstractResourceContainer.java
@@ -1,0 +1,126 @@
+package com.alibaba.rcm.internal;
+
+import com.alibaba.rcm.Constraint;
+import com.alibaba.rcm.ResourceContainer;
+import jdk.internal.misc.VM;
+import jdk.internal.access.SharedSecrets;
+
+import java.util.Collections;
+
+/**
+ * A skeletal implementation of {@link ResourceContainer} that practices
+ * the attach/detach paradigm described in {@link ResourceContainer#run(Runnable)}.
+ * <p>
+ * Each {@code ResourceContainer} implementation must inherit from this class.
+ *
+ * @see ResourceContainer#run(Runnable)
+ */
+
+public abstract class AbstractResourceContainer implements ResourceContainer {
+
+    protected final static AbstractResourceContainer ROOT = new RootContainer();
+
+    public static AbstractResourceContainer root() {
+        return ROOT;
+    }
+
+    public static AbstractResourceContainer current() {
+        if (!VM.isBooted()) {
+            // JLA will be available only after full VM bootstrap.
+            // before that stage, we assume VM is running in ROOT container.
+            return ROOT;
+        }
+        return SharedSecrets.getJavaLangAccess().getResourceContainer(Thread.currentThread());
+    }
+
+    @Override
+    public void run(Runnable command) {
+        if (getState() != State.RUNNING) {
+            throw new IllegalStateException("container not running");
+        }
+        ResourceContainer container = current();
+        if (container == this) {
+            command.run();
+        } else {
+            if (container != ROOT) {
+                throw new IllegalStateException("must be in root container " +
+                        "before running into non-root container.");
+            }
+            attach();
+            try {
+                command.run();
+            } finally {
+                detach();
+            }
+        }
+    }
+
+    /**
+     * Attach to this resource container.
+     * Ensure {@link ResourceContainer#current()} as a root container
+     * before calling this method.
+     * <p>
+     * The implementation class must call {@code super.attach()} to coordinate
+     * with {@link ResourceContainer#current()}
+     */
+    protected void attach() {
+        SharedSecrets.getJavaLangAccess().setResourceContainer(Thread.currentThread(), this);
+    }
+
+    /**
+     * Detach from this resource container and return to root container.
+     * <p>
+     * The implementation class must call {@code super.detach()} to coordinate
+     * with {@link ResourceContainer#current()}
+     */
+    protected void detach() {
+        SharedSecrets.getJavaLangAccess().setResourceContainer(Thread.currentThread(), root());
+    }
+
+    private static class RootContainer extends AbstractResourceContainer {
+        @Override
+        public void run(Runnable command) {
+            AbstractResourceContainer container = current();
+            if (container == ROOT) {
+                command.run();
+                return;
+            }
+            container.detach();
+            try {
+                command.run();
+            } finally {
+                container.attach();
+            }
+        }
+
+        @Override
+        public ResourceContainer.State getState() {
+            return ResourceContainer.State.RUNNING;
+        }
+
+        @Override
+        protected void attach() {
+            throw new UnsupportedOperationException("should not reach here");
+        }
+
+        @Override
+        protected void detach() {
+            throw new UnsupportedOperationException("should not reach here");
+        }
+
+        @Override
+        public void updateConstraint(Constraint constraint) {
+            throw new UnsupportedOperationException("updateConstraint() is not supported by root container");
+        }
+
+        @Override
+        public Iterable<Constraint> getConstraints() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void destroy() {
+            throw new UnsupportedOperationException("destroy() is not supported by root container");
+        }
+    }
+}

--- a/src/java.base/share/classes/com/alibaba/rcm/internal/AbstractResourceContainer.java
+++ b/src/java.base/share/classes/com/alibaba/rcm/internal/AbstractResourceContainer.java
@@ -2,10 +2,12 @@ package com.alibaba.rcm.internal;
 
 import com.alibaba.rcm.Constraint;
 import com.alibaba.rcm.ResourceContainer;
+import jdk.internal.access.RCMAccesss;
 import jdk.internal.misc.VM;
 import jdk.internal.access.SharedSecrets;
 
 import java.util.Collections;
+import java.util.function.Predicate;
 
 /**
  * A skeletal implementation of {@link ResourceContainer} that practices
@@ -18,7 +20,29 @@ import java.util.Collections;
 
 public abstract class AbstractResourceContainer implements ResourceContainer {
 
+    static {
+        setRCMAccess();
+    }
+
+    private static final Predicate<Thread> DEFAULT_PREDICATE = new Predicate<Thread>() {
+        @Override
+        public boolean test(Thread thread) {
+            return true;
+        }
+    };
+
+    private static void setRCMAccess() {
+        SharedSecrets.setRCMAccesss(new RCMAccesss(){
+
+            @Override
+            public Predicate<Thread> getResourceContainerInheritancePredicate(ResourceContainer container) {
+                return ((AbstractResourceContainer) container).threadInherited;
+            }
+        });
+    }
+
     protected final static AbstractResourceContainer ROOT = new RootContainer();
+    private Predicate<Thread> threadInherited = DEFAULT_PREDICATE;
 
     public static AbstractResourceContainer root() {
         return ROOT;
@@ -76,6 +100,11 @@ public abstract class AbstractResourceContainer implements ResourceContainer {
     protected void detach() {
         SharedSecrets.getJavaLangAccess().setResourceContainer(Thread.currentThread(), root());
     }
+
+    void setUnsafeThreadInheritancePredicate(Predicate<Thread> predicate) {
+        this.threadInherited = predicate;
+    }
+
 
     private static class RootContainer extends AbstractResourceContainer {
         @Override

--- a/src/java.base/share/classes/com/alibaba/rcm/internal/RCMUnsafe.java
+++ b/src/java.base/share/classes/com/alibaba/rcm/internal/RCMUnsafe.java
@@ -1,0 +1,33 @@
+package com.alibaba.rcm.internal;
+
+
+import com.alibaba.rcm.ResourceContainer;
+
+import java.util.function.Predicate;
+
+/**
+ * Provide unsafe access to internal ResourceContainer management,
+ * such as predicate whether inheriting current thread or not, set
+ * current ResourceContainer's inheritance callback.
+ * <p>
+ * Extra attention is required when using this class.
+ */
+public final class RCMUnsafe {
+    /**
+     * Set a runtime predicate to control thread's {@link  ResourceContainer}
+     * inheritance behavior, here is an example for inheriting parent thread's
+     * context resource container to current child thread only if a thread is
+     * named "tenantWorker".
+     * {
+     *      ResourceContainer container = ResourceContainerFactory.createContainer();
+     *      RCMUnsafe.setResourceContainerInheritancePredicate(container,
+     *      (thread) -> thread.getName().equals("tenantWorker");
+     * }
+     *
+     * @param container which container to set predicate on
+     * @param predicate which predicate would be used at runtime
+     */
+    public static void setResourceContainerInheritancePredicate(ResourceContainer container, Predicate<Thread> predicate) {
+        ((AbstractResourceContainer) container).setUnsafeThreadInheritancePredicate(predicate);
+    }
+}

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispConfiguration.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispConfiguration.java
@@ -49,8 +49,10 @@ class WispConfiguration {
     // io
     static final boolean WISP_ENABLE_SOCKET_LOCK;
 
-    private static List<String> THREAD_AS_WISP_BLACKLIST;
+    // wisp control group
+    static final int WISP_CONTROL_GROUP_CFS_PERIOD;
 
+    private static List<String> THREAD_AS_WISP_BLACKLIST;
 
     static {
         Properties p = java.security.AccessController.doPrivileged(
@@ -106,6 +108,9 @@ class WispConfiguration {
         WISP_ENABLE_SOCKET_LOCK = parseBooleanParameter(p, "com.alibaba.wisp.useSocketLock", true);
         CARRIER_GROW = parseBooleanParameter(p, "com.alibaba.wisp.growCarrier", false);
         SYSMON_CARRIER_GROW_TICK_US = parsePositiveIntegerParameter(p, "com.alibaba.wisp.growCarrierTickUs", (int) TimeUnit.SECONDS.toMicros(5));
+        // WISP_CONTROL_GROUP_CFS_PERIOD default value is 0(Us), WispControlGroup will estimate a cfs period according to SYSMON_TICK_US.
+        // If WISP_CONTROL_GROUP_CFS_PERIOD was configed by user, WispControlGroup will adopt it directly and won't estimate.
+        WISP_CONTROL_GROUP_CFS_PERIOD = parsePositiveIntegerParameter(p, "com.alibaba.wisp.controlGroup.cfsPeriod", 0);
         checkCompatibility();
     }
 
@@ -137,7 +142,7 @@ class WispConfiguration {
         }
         int res = defaultVal;
         try {
-            res = Integer.valueOf(value);
+            res = Integer.parseInt(value);
         } catch (NumberFormatException e) {
             return defaultVal;
         }
@@ -149,7 +154,7 @@ class WispConfiguration {
         if (p == null || (value = p.getProperty(key)) == null) {
             return defaultVal;
         }
-        return Boolean.valueOf(value);
+        return Boolean.parseBoolean(value);
     }
 
     private static List<String> parseListParameter(Properties p, Properties confProp, String key) {

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispControlGroup.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispControlGroup.java
@@ -1,0 +1,273 @@
+package com.alibaba.wisp.engine;
+
+import com.alibaba.rcm.Constraint;
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceType;
+import com.alibaba.rcm.internal.AbstractResourceContainer;
+
+import java.util.List;
+import java.util.Collections;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * WispControlGroup is used to limit a group of wisp threads'{@link WispTask}
+ * cpu resource consumption. WispControlGroup is similar to cgroup cpu_cfs
+ * function.
+ */
+class WispControlGroup extends AbstractExecutorService {
+
+    // the accuracy of CPU control group based on WispTask depends very much on a
+    // WispTask's
+    // schedule times in one cfs period, so make sure there are at least 5 times
+    // schedule
+    // chance in one cfs period.
+    private static final int SCHEDULE_TIMES = 5;
+    // limit max period duration 100ms.
+    private static final int MAX_PERIOD = 100_000;
+    // limit min period duration 10ms.
+    private static final int MIN_PERIOD = 10_000;
+    /**
+     * ESTIMATED_PERIOD is an estimated cpu_cfs period according to wisp preemptive
+     * schedule period, make sure there are at least SCHEDULE_TIMES wisp schedule
+     * happen during cpu_cfs period, which is crucial to cpu_cfs accuracy. And also
+     * restrict ESTIMATED_PERIOD in scope [MIN_PERIOD, MAX_PERIOD];
+     */
+    private static final int ESTIMATED_PERIOD = Math.max(MIN_PERIOD,
+            Math.min(MAX_PERIOD, WispConfiguration.SYSMON_TICK_US * SCHEDULE_TIMES));
+
+    private static int defaultCfsPeriod() {
+        // prior to adopt configured cfs period.
+        int cfsPeriodUs = WispConfiguration.WISP_CONTROL_GROUP_CFS_PERIOD;
+        // estimate cpu_cfs quota according to cpu_cfs and giving maxCPUPercent.
+        return cfsPeriodUs == 0 ? ESTIMATED_PERIOD : cfsPeriodUs;
+    }
+
+    /**
+     * @param quota  max cpu time slice in one period{@param period} the
+     *               WispControlGroup could consume.
+     * @param period cpu time consumption accounting unit.
+     * @return {@link WispControlGroup}.
+     */
+    static WispControlGroup newInstance(int quota, int period) {
+        return new WispControlGroup(quota, period);
+    }
+
+    static WispControlGroup newInstance(int maxCPUPercent) {
+        int cfsPeriodUs = defaultCfsPeriod();
+        int cfsQuotaUs = (int) ((double) cfsPeriodUs * maxCPUPercent / 100);
+        return new WispControlGroup(cfsQuotaUs, cfsPeriodUs);
+    }
+
+    // newInstance() should only be used for creating an ResourceContainer.
+    static WispControlGroup newInstance() {
+        int cfsPeriodUs = defaultCfsPeriod();
+        int cfsQuotaUs = cfsPeriodUs * Runtime.getRuntime().availableProcessors();
+        return new WispControlGroup(cfsPeriodUs, cfsQuotaUs);
+    }
+
+    private WispControlGroup(int cfsQuotaUs, int cfsPeriodUs) {
+        if (cfsQuotaUs <= 0 || cfsPeriodUs <= 0) {
+            throw new IllegalArgumentException(
+                    "Invalid parameter: cfsQuotaUs or cfsPeriodUs should be positive number");
+        }
+        this.cpuLimit = new CpuLimit(cfsQuotaUs, cfsPeriodUs);
+        this.currentPeriodStart = new AtomicLong();
+        this.remainQuota = new AtomicLong();
+    }
+
+    private CpuLimit cpuLimit;
+    private AtomicLong currentPeriodStart;
+    private AtomicLong remainQuota;
+
+    private static class CpuLimit {
+        long cfsPeriod;
+        long cfsQuota;
+
+        CpuLimit(int cfsQuotaUs, int cfsPeriodUs) {
+            cfsQuota = TimeUnit.MICROSECONDS.toNanos(cfsQuotaUs);
+            cfsPeriod = TimeUnit.MICROSECONDS.toNanos(cfsPeriodUs);
+        }
+    }
+
+    /**
+     * Need to be called by wispEngine before task run
+     *
+     * @param updateTs: indicate whether update wisp task's enterTs, it still need
+     *                  to update this field despite there is no time slice left
+     *                  under some special scenes.
+     * @return x == 0: if it's ok to run the task; x > 0, quota exceed, need to
+     *         delay x nanoseconds.
+     */
+    long checkCpuLimit(WispTask task, boolean updateTs) {
+        assert task.controlGroup == this;
+        assert task.enterTs == 0; // clean by calcCpuTicks
+        CpuLimit limit = this.cpuLimit;
+        long now = System.nanoTime();
+        long cp = currentPeriodStart.get();
+        if (now > cp + limit.cfsPeriod && currentPeriodStart.compareAndSet(cp, now)) {
+            final long quotaInc = (long) ((now - cp) / (double) limit.cfsPeriod * limit.cfsQuota);
+            cp = now;
+            long q;
+            do {
+                q = remainQuota.get();
+            } while (!remainQuota.compareAndSet(q, Math.min(q + quotaInc, limit.cfsQuota)));
+        }
+        long q = remainQuota.get();
+        if (q >= 0) {
+            task.enterTs = System.nanoTime();
+            task.ttr = 0;
+            return 0;
+        }
+        if (updateTs) {
+            task.enterTs = System.nanoTime();
+        }
+        long timeToResume = (long) (-q / (double) limit.cfsQuota * limit.cfsPeriod);
+        timeToResume = Math.max(timeToResume, cp + limit.cfsPeriod - now);
+        task.ttr = timeToResume / 1000;
+        assert timeToResume > 0;
+        return timeToResume;
+    }
+
+    void calcCpuTicks(WispTask task) {
+        assert task.controlGroup == this;
+        assert task.enterTs != 0;
+        long usage = System.nanoTime() - task.enterTs;
+        remainQuota.addAndGet(-usage);
+        task.enterTs = 0;
+    }
+
+    private void attach() {
+        WispTask task = WispCarrier.current().current;
+        assert task.controlGroup == null;
+        task.controlGroup = this;
+        long delay = checkCpuLimit(task, true);
+        if (delay != 0) {
+            WispTask.jdkPark(delay);
+        }
+        assert task.enterTs != 0;
+    }
+
+    private void detach() {
+        WispTask task = WispCarrier.current().current;
+        assert task.controlGroup != null;
+        task.controlGroup.calcCpuTicks(task);
+        task.controlGroup = null;
+    }
+
+    Runnable wrap(Runnable command) {
+        return () -> {
+            attach();
+            try {
+                // must run the command in runOutsideWisp wrap, otherwise preempt will be
+                // prevented by Coroutine::in_critical during command running.
+                WispTask.runOutsideWisp(command);
+            } finally {
+                detach();
+            }
+        };
+    }
+
+    /**
+     * execute a Runnable in asynchronous mode as a wrapped
+     * WispTask{@link WispTask}, wrap will attach running WispTask to current
+     * WispControlGroup and then run the giving command.
+     */
+    @Override
+    public void execute(Runnable command) {
+        WispEngine.dispatch(wrap(command));
+    }
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException("NYI");
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return null;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        CpuLimit limit = this.cpuLimit;
+        return "WispControlGroup{" + limit.cfsQuota / 1000 + "/" + limit.cfsPeriod / 1000 + '}';
+    }
+
+    ResourceContainer createResourceContainer() {
+        return new AbstractResourceContainer() {
+            private Constraint constraint;
+
+            @Override
+            public State getState() {
+                if (isTerminated()) {
+                    return State.DEAD;
+                } else if (isShutdown()) {
+                    return State.STOPPING;
+                } else {
+                    return State.RUNNING;
+                }
+            }
+
+            @Override
+            public void updateConstraint(Constraint constraint) {
+                /* check resource type contained in constraint must be CPU_PERCENT */
+                if (constraint.getResourceType() != ResourceType.CPU_PERCENT) {
+                    throw new IllegalArgumentException("Resource type is not CPU_PERCENT");
+                }
+                this.constraint = constraint;
+                long[] para = constraint.getValues();
+                long cpuPercent = para[0];
+                int cfsPeriod = defaultCfsPeriod();
+                int cfsQuota = (int) ((double) cfsPeriod * cpuPercent / 100);
+                cpuLimit = new CpuLimit(cfsQuota, cfsPeriod);
+            }
+
+            @Override
+            public Iterable<Constraint> getConstraints() {
+                assert constraint != null;
+                return Collections.singletonList(constraint);
+            }
+
+            @Override
+            public void destroy() {
+                shutdown();
+                while (!isTerminated()) {
+                    try {
+                        awaitTermination(1, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        throw new InternalError(e);
+                    }
+                }
+            }
+
+            @Override
+            protected void attach() {
+                super.attach();
+                WispControlGroup.this.attach();
+            }
+
+            @Override
+            protected void detach() {
+                WispControlGroup.this.detach();
+                super.detach();
+            }
+        };
+    }
+}

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -139,9 +139,11 @@ public class WispEngine extends AbstractExecutorService {
             new ConcurrentLinkedQueue<>().iterator();
             new ConcurrentSkipListMap<>().keySet().iterator();
             WispCarrier carrier = WispCarrier.current();
-            carrier.addTimer(System.nanoTime() + Integer.MAX_VALUE, false);
+            carrier.addTimer(System.nanoTime() + Integer.MAX_VALUE, TimeOut.Action.JDK_UNPARK);
             carrier.cancelTimer();
             carrier.createResumeEntry(new WispTask(carrier, null, false, false));
+            // preload classes used by by constraintInResourceContainer method.
+            WispTask.wrapRunOutsideWisp(null);
             registerPerfCounter(carrier);
             deRegisterPerfCounter(carrier);
             // It will load configuration files and trigger
@@ -225,7 +227,7 @@ public class WispEngine extends AbstractExecutorService {
 
             @Override
             public void addTimer(long deadlineNano) {
-                WispCarrier.current().addTimer(deadlineNano, false);
+                WispCarrier.current().addTimer(deadlineNano, TimeOut.Action.JDK_UNPARK);
             }
 
             @Override

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispResourceContainerFactory.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispResourceContainerFactory.java
@@ -1,0 +1,41 @@
+package com.alibaba.wisp.engine;
+
+import com.alibaba.rcm.Constraint;
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceContainerFactory;
+
+/**
+ * Singleton factory specialized for wisp control group
+ * {@code ResourceContainer} Theoretically with support of new RCM API.
+ * (com.alibaba.rcm) {@code WispResourceContainerFactory} will be the only class
+ * need to be exported from package {@code com.alibaba.wisp.engine}.
+ */
+public final class WispResourceContainerFactory implements ResourceContainerFactory {
+    /**
+     * @param constraints the target {@code Constraint}s
+     * @return Singleton instance of WispResourceContainerFactory
+     */
+    @Override
+    public ResourceContainer createContainer(final Iterable<Constraint> constraints) {
+        final ResourceContainer container = WispControlGroup.newInstance().createResourceContainer();
+        for (final Constraint constraint : constraints) {
+            container.updateConstraint(constraint);
+        }
+        return container;
+    }
+
+    private WispResourceContainerFactory() {
+    }
+
+    private static final class Holder {
+        private static final WispResourceContainerFactory INSTANCE = new WispResourceContainerFactory();
+    }
+
+    /**
+     * @param
+     * @return Singleton instance of WispResourceContainerFactory
+     */
+    public static WispResourceContainerFactory instance() {
+        return Holder.INSTANCE;
+    }
+}

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
@@ -1,5 +1,6 @@
 package com.alibaba.wisp.engine;
 
+import com.alibaba.rcm.ResourceContainer;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.UnsafeAccess;
 
@@ -12,6 +13,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
+
 
 /**
  * {@link WispTask} provides high-level semantics of {link @Coroutine}
@@ -101,7 +103,6 @@ public class WispTask implements Comparable<WispTask> {
     TimeOut timeOut;                    // related timer
     ClassLoader ctxClassLoader;
 
-    WispTask parent;
     private final boolean isThreadTask;
     private boolean isThreadAsWisp;
 
@@ -122,6 +123,7 @@ public class WispTask implements Comparable<WispTask> {
     int stealCount;
     int stealFailureCount;
     private int preemptCount;
+    long ttr;
     // perf monitor
     private long enqueueTime;
     private long parkTime;
@@ -132,6 +134,9 @@ public class WispTask implements Comparable<WispTask> {
     private volatile long epollArray;
     private volatile int epollEventNum;
     int epollArraySize;
+
+    WispControlGroup controlGroup;
+    long enterTs;
 
     WispTask(WispCarrier carrier, Coroutine ctx, boolean isRealTask, boolean isThreadTask) {
         this.isThreadTask = isThreadTask;
@@ -146,12 +151,12 @@ public class WispTask implements Comparable<WispTask> {
         resumeEntry = isThreadTask ? null : carrier.createResumeEntry(this);
     }
 
-    void reset(Runnable runnable, WispTask parent, String name, Thread thread, ClassLoader ctxLoader) {
+    void reset(Runnable runnable, String name, Thread thread, ClassLoader ctxLoader) {
         assert ctx != null;
         this.status       = Status.ALIVE;
         this.runnable     = runnable;
-        this.parent       = parent;
         this.name         = name;
+        this.controlGroup = null;
         interrupted       = 0;
         ctxClassLoader    = ctxLoader;
         ch                = null;
@@ -217,11 +222,12 @@ public class WispTask implements Comparable<WispTask> {
                 if (runnable != null) {
                     Throwable throwable = null;
                     try {
-                        runOutsideWisp(runnable);
+                        runCommand();
                     } catch (Throwable t) {
                         throwable = t;
                     } finally {
                         assert timeOut == null;
+                        assert controlGroup == null; // detached
                         runnable = null;
                         WispEngine.JLA.setWispAlive(threadWrapper, false);
                         if (isThreadAsWisp) {
@@ -239,14 +245,27 @@ public class WispTask implements Comparable<WispTask> {
         }
     }
 
+    private void runCommand() {
+        ResourceContainer irc = WispEngine.JLA.getInheritedResourceContainer(threadWrapper);
+        if (irc != ResourceContainer.root()) {
+            irc.run(wrapRunOutsideWisp(runnable));
+        } else {
+            runOutsideWisp(runnable);
+        }
+    }
+
     /**
      * Mark if wisp is running internal scheduling code or user code, this would
      * be used in preempt to identify if it's okay to preempt
      * Modify Coroutine::is_usermark_frame accordingly if you need to change this
      * method, because it's name and sig are used
      */
-    private static void runOutsideWisp(Runnable runnable) {
+    static void runOutsideWisp(Runnable runnable) {
         runnable.run();
+    }
+
+    static Runnable wrapRunOutsideWisp(Runnable runnable) {
+        return () -> runOutsideWisp(runnable);
     }
 
     /**
@@ -356,7 +375,8 @@ public class WispTask implements Comparable<WispTask> {
                     // current task is put to unpark queue,
                     // and will wake up eventually
                     if (WispEngine.runningAsCoroutine(threadWrapper) && timeoutNano > 0) {
-                        carrier.addTimer(timeoutNano + System.nanoTime(), fromJvm);
+                        carrier.addTimer(timeoutNano + System.nanoTime(),
+                                fromJvm ? TimeOut.Action.JVM_UNPARK : TimeOut.Action.JDK_UNPARK);
                     }
                     carrier.isInCritical = isInCritical0;
                     try {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -66,6 +66,8 @@ import java.util.WeakHashMap;
 import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+
+import com.alibaba.rcm.internal.AbstractResourceContainer;
 import com.alibaba.wisp.engine.WispEngine;
 import com.alibaba.wisp.engine.WispTask;
 import jdk.internal.misc.Unsafe;
@@ -2492,6 +2494,22 @@ public final class System {
             @Override
             public void wispBooted() {
                 Thread.wispBooted();
+            }
+
+
+            @Override
+            public void setResourceContainer(Thread thread, AbstractResourceContainer container) {
+                thread.resourceContainer = container;
+            }
+
+            @Override
+            public AbstractResourceContainer getResourceContainer(Thread thread) {
+                return thread.resourceContainer;
+            }
+
+            @Override
+            public AbstractResourceContainer getInheritedResourceContainer(Thread thread) {
+                return thread.inheritedResourceContainer;
             }
         });
     }

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -43,6 +43,7 @@ import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import com.alibaba.rcm.internal.AbstractResourceContainer;
 import com.alibaba.wisp.engine.WispEngine;
 import com.alibaba.wisp.engine.WispTask;
 import jdk.internal.access.SharedSecrets;
@@ -223,6 +224,19 @@ public class Thread implements Runnable {
      * Java thread status for tools, default indicates thread 'not yet started'
      */
     private volatile int threadStatus;
+
+    /**
+    /**
+     * The thread attached {@code ResourceContainer}
+     */
+    AbstractResourceContainer resourceContainer;
+
+    /**
+     * {@code ResourceContainer} inherited from parent
+     */
+    AbstractResourceContainer inheritedResourceContainer;
+
+
 
     /**
      * The argument supplied to the current call to
@@ -550,6 +564,10 @@ public class Thread implements Runnable {
 
         /* Set thread ID */
         this.tid = nextThreadID();
+
+        // com.alibaba.rcm API
+        this.resourceContainer = AbstractResourceContainer.root();
+        this.inheritedResourceContainer = parent.resourceContainer;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -43,7 +43,9 @@ import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import com.alibaba.rcm.ResourceContainer;
 import com.alibaba.rcm.internal.AbstractResourceContainer;
+import com.alibaba.rcm.internal.RCMUnsafe;
 import com.alibaba.wisp.engine.WispEngine;
 import com.alibaba.wisp.engine.WispTask;
 import jdk.internal.access.SharedSecrets;
@@ -567,7 +569,12 @@ public class Thread implements Runnable {
 
         // com.alibaba.rcm API
         this.resourceContainer = AbstractResourceContainer.root();
-        this.inheritedResourceContainer = parent.resourceContainer;
+        if (SharedSecrets.getRCMAccess().getResourceContainerInheritancePredicate(
+                parent.resourceContainer).test(this)) {
+            this.inheritedResourceContainer = parent.resourceContainer;
+        } else {
+            this.inheritedResourceContainer = AbstractResourceContainer.root();
+        }
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
+import com.alibaba.rcm.internal.AbstractResourceContainer;
 import com.alibaba.wisp.engine.WispTask;
 import jdk.internal.module.ServicesCatalog;
 import jdk.internal.reflect.ConstantPool;
@@ -430,4 +431,21 @@ public interface JavaLangAccess {
     void threadExit(Thread thread);
 
     void wispBooted();
+
+    /**
+     * Set the value of {@code thread.resourceContainer}
+     *
+     * @param thread target thread to be modified
+     */
+    void setResourceContainer(Thread thread, AbstractResourceContainer container);
+
+    /**
+     * Get the reference to the thread attached {@code ResourceContainer}
+     */
+    AbstractResourceContainer getResourceContainer(Thread thread);
+
+    /**
+     * Get the reference to the thread's inherited {@code ResourceContainer}
+     */
+    AbstractResourceContainer getInheritedResourceContainer(Thread thread);
 }

--- a/src/java.base/share/classes/jdk/internal/access/RCMAccesss.java
+++ b/src/java.base/share/classes/jdk/internal/access/RCMAccesss.java
@@ -1,0 +1,14 @@
+package jdk.internal.access;
+
+import com.alibaba.rcm.ResourceContainer;
+
+import java.util.function.Predicate;
+
+public interface RCMAccesss {
+    /**
+     * Get container's thread inheritance predicate.
+     * @param container current child container in parent thread's context
+     * @return parent thread's inheritance predicate
+     */
+    public Predicate<Thread> getResourceContainerInheritancePredicate(ResourceContainer container);
+}

--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -89,6 +89,7 @@ public class SharedSecrets {
     private static JavaxCryptoSpecAccess javaxCryptoSpecAccess;
     private static WispEngineAccess wispEngineAccess;
     private static EpollAccess epollAccess;
+    private static RCMAccesss rcmAccesss;
 
     public static void setJavaUtilCollectionAccess(JavaUtilCollectionAccess juca) {
         javaUtilCollectionAccess = juca;
@@ -485,5 +486,13 @@ public class SharedSecrets {
 
     public static void setEpollAccess(EpollAccess epollAccess) {
         SharedSecrets.epollAccess = epollAccess;
+    }
+
+    public static RCMAccesss getRCMAccess() {
+        return rcmAccesss;
+    }
+
+    public static void setRCMAccesss(RCMAccesss rcmAccesss) {
+        SharedSecrets.rcmAccesss = rcmAccesss;
     }
 }

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -130,6 +130,7 @@ module java.base {
     exports javax.security.auth.spi;
     exports javax.security.auth.x500;
     exports javax.security.cert;
+    exports com.alibaba.rcm;
     exports com.alibaba.wisp.engine;
 
 

--- a/src/jdk.management/share/classes/com/alibaba/management/WispCounterMXBean.java
+++ b/src/jdk.management/share/classes/com/alibaba/management/WispCounterMXBean.java
@@ -121,5 +121,5 @@ public interface WispCounterMXBean extends PlatformManagedObject {
      * @param id WispEngine id
      * @return WispCounterData
      */
-    WispCounterData getWispCounterData(long id);
+    WispCounterData getWispCounter(long id);
 }

--- a/src/jdk.management/share/classes/com/alibaba/management/internal/WispCounterMXBeanImpl.java
+++ b/src/jdk.management/share/classes/com/alibaba/management/internal/WispCounterMXBeanImpl.java
@@ -134,9 +134,9 @@ public class WispCounterMXBeanImpl implements com.alibaba.management.WispCounter
      * @return WispCounterData
      */
     @Override
-    public WispCounterData getWispCounterData(long id) {
+    public WispCounterData getWispCounter(long id) {
         WispCounter counter = WispEngine.getWispCounter(id);
-        return new WispCounterData(counter);
+        return counter != null ? new WispCounterData(counter) : null;
     }
 
     private <T> List<T> aggregate(Function<WispCounter, T> getter) {

--- a/test/hotspot/jtreg/runtime/coroutine/TestMemLeak.java
+++ b/test/hotspot/jtreg/runtime/coroutine/TestMemLeak.java
@@ -67,7 +67,7 @@ public class TestMemLeak {
 
         int rss1 = getRssInKb();
         System.out.println(rss1);
-        if (rss1 - rss0 > 1024) { // 1M
+        if (rss1 - rss0 > 1024 * 2) { // 2M
             throw new Error("user created coroutine mem leak");
         }
     }

--- a/test/jdk/com/alibaba/rcm/RcmUtils.java
+++ b/test/jdk/com/alibaba/rcm/RcmUtils.java
@@ -1,0 +1,40 @@
+import com.alibaba.rcm.Constraint;
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.wisp.engine.WispResourceContainerFactory;
+import java.lang.reflect.Field;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static jdk.test.lib.Asserts.fail;
+
+public class RcmUtils {
+    public static final boolean IS_WISP_ENABLED;
+//    public static final boolean IS_TENANT_ENABLED = TenantGlobals.isTenantEnabled();
+
+    static {
+        boolean isWispEnabled = false;
+        try {
+            Field f = Class.forName("com.alibaba.wisp.engine.WispConfiguration")
+                    .getDeclaredField("ENABLE_THREAD_AS_WISP");
+            f.setAccessible(true);
+            isWispEnabled = f.getBoolean(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        IS_WISP_ENABLED = isWispEnabled;
+    }
+
+    public static ResourceContainer createContainer(Iterable<Constraint> constraints) {
+        if (IS_WISP_ENABLED) {
+            return WispResourceContainerFactory.instance()
+                    .createContainer(constraints);
+        } else {
+            fail("Unsupported scenarios");
+        }
+        return null;
+    }
+
+    public static ResourceContainer createContainer(Constraint... constraints) {
+        return createContainer(Stream.of(constraints).collect(Collectors.toList()));
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestConfiguration.java
+++ b/test/jdk/com/alibaba/rcm/TestConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * @test
+ * @summary Test builder and update constraint
+ * @library /test/lib
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main TestConfiguration
+ */
+
+import demo.MyResourceContainer;
+import demo.MyResourceFactory;
+import demo.MyResourceType;
+
+import java.util.Arrays;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class TestConfiguration {
+    public static void main(String[] args) {
+
+        MyResourceContainer mc = (MyResourceContainer) MyResourceFactory.INSTANCE.createContainer(Arrays.asList(
+                MyResourceType.MY_RESOURCE1.newConstraint(),
+                MyResourceType.MY_RESOURCE2.newConstraint()));
+
+        assertTrue(iterator2Stream(mc.operations.iterator()).collect(Collectors.toSet())
+                .equals(new HashSet<>(Arrays.asList("update " + MyResourceType.MY_RESOURCE1.toString(),
+                                                    "update " + MyResourceType.MY_RESOURCE2.toString()))));
+
+        mc.updateConstraint(MyResourceType.MY_RESOURCE2.newConstraint());
+
+        assertTrue(iterator2Stream(mc.operations.iterator()).collect(Collectors.toSet())
+                .equals(new HashSet<>(Arrays.asList("update " + MyResourceType.MY_RESOURCE1.toString(),
+                                                    "update " + MyResourceType.MY_RESOURCE2.toString(),
+                                                    "update " + MyResourceType.MY_RESOURCE2.toString()))));
+    }
+
+    private static <T> Stream<T> iterator2Stream(Iterator<T> iterator) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
+                false);
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestExceptionPreidicate.java
+++ b/test/jdk/com/alibaba/rcm/TestExceptionPreidicate.java
@@ -1,0 +1,56 @@
+/*
+ * @test
+ * @library /test/lib
+ * @build TestExceptionPreidicate RcmUtils
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @summary test RCM thread inheritance callback throw exception .
+ * @run main/othervm -XX:+UseWisp2 -XX:ActiveProcessorCount=4 TestExceptionPreidicate
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceType;
+import com.alibaba.rcm.internal.RCMUnsafe;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class TestExceptionPreidicate {
+
+    public static void main(String[] args) throws Exception {
+        testException();
+        testRecursive();
+    }
+
+    private static void testRecursive() throws InterruptedException {
+        ResourceContainer container = RcmUtils.createContainer(ResourceType.CPU_PERCENT.newConstraint(40));
+        RCMUnsafe.setResourceContainerInheritancePredicate(container, t -> new Thread().equals(t));
+        CountDownLatch latch = new CountDownLatch(1);
+        container.run(() -> {
+            try {
+                new Thread(latch::countDown).start();
+            } catch (StackOverflowError e) {
+                //expected
+            }
+        });
+        assertFalse(latch.await(1, TimeUnit.SECONDS));
+    }
+
+    private static void testException() throws InterruptedException {
+        ResourceContainer container = RcmUtils.createContainer(ResourceType.CPU_PERCENT.newConstraint(40));
+        Object obj = null;
+        CountDownLatch latch = new CountDownLatch(1);
+        RCMUnsafe.setResourceContainerInheritancePredicate(container, t -> obj.hashCode() == 0);
+        container.run(() -> {
+                    try {
+                        new Thread(latch::countDown).start();
+                    } catch (Exception e) {
+                        //expected
+                    }
+                });
+        assertFalse(latch.await(1, TimeUnit.SECONDS));
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestInherit.java
+++ b/test/jdk/com/alibaba/rcm/TestInherit.java
@@ -1,0 +1,58 @@
+/*
+ * @test
+ * @summary Test resource container is inherited from parent
+ * @library /test/lib
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main TestInherit
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import demo.RCInheritedThreadFactory;
+import demo.MyResourceFactory;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
+import static jdk.test.lib.Asserts.assertEQ;
+
+public class TestInherit {
+    public static void main(String[] args) {
+        assertEQ(ResourceContainer.current(), ResourceContainer.root());
+        ResourceContainer rc = MyResourceFactory.INSTANCE.createContainer(Collections.emptyList());
+        rc.run(() -> {
+            assertEQ(ResourceContainer.current(), rc);
+            FutureTask<ResourceContainer> f1 = new FutureTask<>(ResourceContainer::current);
+            RCInheritedThreadFactory.INSTANCE.newThread(f1).start();
+            assertEQ(get(f1), rc);
+            FutureTask<ResourceContainer> f2 = new FutureTask<>(ResourceContainer::current);
+            ResourceContainer.root().run(() -> RCInheritedThreadFactory.INSTANCE.newThread(f2).start());
+            assertEQ(get(f2), ResourceContainer.root());
+        });
+
+        // thread is bound to it's parent thread(the thread called Thread::init())
+        // not dependent on where Thread::start() called.
+        FutureTask<ResourceContainer> f3 = new FutureTask<>(ResourceContainer::current);
+        Thread t3 = RCInheritedThreadFactory.INSTANCE.newThread(f3);
+        // Thread::init is called in root()
+        rc.run(t3::start);
+        assertEQ(get(f3), ResourceContainer.root());
+
+        FutureTask<ResourceContainer> f4 = new FutureTask<>(ResourceContainer::current);
+        FutureTask<Thread> newThread = new FutureTask<>(() -> RCInheritedThreadFactory.INSTANCE.newThread(f4));
+        // Thread::init is called in container
+        rc.run(newThread);
+        get(newThread).start();
+        assertEQ(get(f4), rc);
+    }
+
+    private static <V> V get(Future<V> f) {
+        try {
+            return f.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new InternalError(e);
+        }
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestInheritedContainer.java
+++ b/test/jdk/com/alibaba/rcm/TestInheritedContainer.java
@@ -1,0 +1,36 @@
+/*
+ * @test
+ * @summary Test ONLY inheritedResourceContainer is inherited from parent
+ * @library /test/lib
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main TestInheritedContainer
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import demo.MyResourceFactory;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.JavaLangAccess;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import static jdk.test.lib.Asserts.assertEQ;
+
+
+public class TestInheritedContainer {
+    public static void main(String[] args) throws Exception {
+        ResourceContainer rc = MyResourceFactory.INSTANCE.createContainer(Collections.emptyList());
+        JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+        rc.run(() -> {
+            try {
+                assertEQ(ResourceContainer.root(),
+                        CompletableFuture.supplyAsync(() -> JLA.getResourceContainer(Thread.currentThread())).get());
+                assertEQ(rc,
+                        CompletableFuture.supplyAsync(() -> JLA.getInheritedResourceContainer(Thread.currentThread())).get());
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        });
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestRCMInheritanceCallBack.java
+++ b/test/jdk/com/alibaba/rcm/TestRCMInheritanceCallBack.java
@@ -1,0 +1,50 @@
+/*
+ * @test
+ * @library /test/lib
+ * @build TestRCMInheritanceCallBack RcmUtils
+ * @summary test RCM cpu resource control.
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main/othervm -XX:+UseWisp2 -XX:ActiveProcessorCount=4 TestRCMInheritanceCallBack
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceType;
+import com.alibaba.rcm.internal.RCMUnsafe;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class TestRCMInheritanceCallBack {
+    public static void main(String[] args) throws Exception {
+        ResourceContainer container = RcmUtils.createContainer(ResourceType.CPU_PERCENT.newConstraint(100));
+        RCMUnsafe.setResourceContainerInheritancePredicate(container, thread -> thread.getName().startsWith("Tenant"));
+        CountDownLatch latch = new CountDownLatch(2);
+
+        container.run(() -> {
+            Thread t = new Thread(() -> {
+                assertInRoot(false);
+                latch.countDown();
+            }, "TenantWorker");
+            t.start();
+        });
+
+        container.run(() -> {
+            Thread t = new Thread(() -> {
+                assertInRoot(true);
+                latch.countDown();
+            });
+            t.start();
+        });
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+    }
+
+    private static void assertInRoot(boolean flag) {
+        assertEQ(flag, ResourceContainer.current() == ResourceContainer.root());
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestRcmCpu.java
+++ b/test/jdk/com/alibaba/rcm/TestRcmCpu.java
@@ -1,0 +1,71 @@
+/*
+ * @test
+ * @library /test/lib
+ * @build TestRcmCpu RcmUtils
+ * @summary test RCM cpu resource control.
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main/othervm -XX:+UseWisp2 -XX:ActiveProcessorCount=4 TestRcmCpu
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceType;
+
+import java.security.MessageDigest;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+import static jdk.test.lib.Asserts.assertLT;
+
+public class TestRcmCpu {
+
+    private static Callable<Long> taskFactory(int load) {
+        return new Callable<Long>() {
+            @Override
+            public Long call() throws Exception {
+                long start = System.currentTimeMillis();
+                MessageDigest md5 = MessageDigest.getInstance("MD5");
+                int count = load;
+                while (--count > 0) {
+                    md5.update("hello world!!!".getBytes());
+                    if (count % 20 == 0) {
+                        Thread.yield();
+                    }
+                }
+                return System.currentTimeMillis() - start;
+            }
+        };
+    }
+
+    public static void main(String[] args) throws Exception {
+        ResourceContainer rc0 = RcmUtils.createContainer(
+                ResourceType.CPU_PERCENT.newConstraint(40));
+        ResourceContainer rc1 = RcmUtils.createContainer(
+                ResourceType.CPU_PERCENT.newConstraint(80));
+
+        taskFactory(1_000_000).call(); // warm up
+        Callable<Long> task0 = taskFactory(2_000_000);
+        Callable<Long> task1 = taskFactory(2_000_000);
+        FutureTask<Long> futureTask0 = new FutureTask<>(task0);
+        FutureTask<Long> futureTask1 = new FutureTask<>(task1);
+        ExecutorService es = Executors.newFixedThreadPool(4);
+        es.submit(() -> {
+            System.out.println("start-0");
+            rc0.run(futureTask0);
+            System.out.println("done-0");
+        });
+        es.submit(() -> {
+            System.out.println("start-1");
+            rc1.run(futureTask1);
+            System.out.println("done-1");
+        });
+        Long duration0 = futureTask0.get();
+        Long duration1 = futureTask1.get();
+        es.shutdownNow();
+
+        double ratio = (double) duration1 / duration0;
+        assertLT(Math.abs(ratio - 0.5), 0.10, "deviation is out of reasonable scope");
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestRcmRoot.java
+++ b/test/jdk/com/alibaba/rcm/TestRcmRoot.java
@@ -1,0 +1,79 @@
+/*
+ * @test
+ * @library /test/lib
+ * @build TestRcmRoot RcmUtils
+ * @summary test RCM root API.
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=4 TestRcmRoot
+ */
+
+import jdk.internal.access.SharedSecrets;
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.internal.AbstractResourceContainer;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static jdk.test.lib.Asserts.*;
+
+public class TestRcmRoot {
+
+    public static void main(String[] args) throws Exception {
+        ResourceContainer rc0 = RcmUtils.createContainer();
+        ResourceContainer rc1 = RcmUtils.createContainer();;
+
+        FutureTask future0 = new FutureTask<>(() -> {
+            boolean isException = false;
+            try {
+                ResourceContainer threadContainer = SharedSecrets.getJavaLangAccess()
+                        .getResourceContainer(Thread.currentThread());
+                assertTrue(threadContainer == rc0, "should own the same container as its parent thread!!!");
+                rc1.run(() -> {
+
+                });
+            } catch (IllegalStateException e) {
+                isException = true;
+            } finally {
+                assertTrue(isException, "an expected IllegalStateException should happen");
+            }
+            return null;
+        });
+
+        FutureTask future1 = new FutureTask<>(() -> {
+            boolean isException = false;
+            try {
+                ResourceContainer threadContainer = SharedSecrets.getJavaLangAccess()
+                        .getResourceContainer(Thread.currentThread());
+                assertTrue(threadContainer == rc0, "should own the same container as its parent thread!!!");
+                AbstractResourceContainer.root().run(() -> {
+                    rc1.run(() -> {
+                        try {
+                            ResourceContainer threadContainer1 = SharedSecrets.getJavaLangAccess()
+                                    .getResourceContainer(Thread.currentThread());
+                            assertTrue(threadContainer1 == rc1,
+                                    "should own the same container as its parent thread!!!");
+                        } catch (Exception e) {
+                            assertTrue(false, "unexpected reflection exception happen");
+                        }
+                    });
+                });
+            } catch (IllegalStateException e) {
+                isException = true;
+            } finally {
+                assertFalse(isException, "an IllegalStateException should never happen");
+            }
+            return null;
+        });
+        ExecutorService es = Executors.newFixedThreadPool(4);
+        es.submit(() -> {
+            AbstractResourceContainer.root().run(() -> rc0.run(future0));
+        });
+        es.submit(() -> {
+            AbstractResourceContainer.root().run(() -> rc0.run(future1));
+        });
+        future0.get();
+        future1.get();
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestRcmUpdate.java
+++ b/test/jdk/com/alibaba/rcm/TestRcmUpdate.java
@@ -1,0 +1,27 @@
+/*
+ * @test
+ * @library /test/lib
+ * @build TestRcmUpdate RcmUtils
+ * @summary test RCM updating API.
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @run main/othervm -XX:+UseWisp2 -XX:ActiveProcessorCount=4 TestRcmUpdate
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceType;
+
+import java.util.concurrent.*;
+
+import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.assertFalse;
+
+public class TestRcmUpdate {
+    public static void main(String[] args) throws Exception {
+        ResourceContainer rc0 = RcmUtils.createContainer(ResourceType.CPU_PERCENT.newConstraint(40));
+        assertTrue(rc0.getConstraints().iterator().next().getValues()[0] == 40);
+        rc0.updateConstraint(ResourceType.CPU_PERCENT.newConstraint(1));
+        assertTrue(rc0.getConstraints().iterator().next().getValues()[0] == 1);
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestRootNotNull.java
+++ b/test/jdk/com/alibaba/rcm/TestRootNotNull.java
@@ -1,0 +1,18 @@
+/*
+ * @test
+ * @summary Test default ResourceContainer is root() instead of null
+ * @library /test/lib
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main TestRootNotNull
+ */
+
+import jdk.internal.access.SharedSecrets;
+
+import static jdk.test.lib.Asserts.assertNotNull;
+
+public class TestRootNotNull {
+    public static void main(String[] args) {
+        assertNotNull(SharedSecrets.getJavaLangAccess().getResourceContainer(Thread.currentThread()));
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestSkeletalAttach.java
+++ b/test/jdk/com/alibaba/rcm/TestSkeletalAttach.java
@@ -1,0 +1,61 @@
+/*
+ * @test
+ * @summary Test skeletal implementation in AbstractResourceContainer
+ * @library /test/lib
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main TestSkeletalAttach
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import demo.MyResourceContainer;
+import demo.MyResourceFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+
+public class TestSkeletalAttach {
+    public static void main(String[] args) {
+        MyResourceContainer rc = (MyResourceContainer) MyResourceFactory.INSTANCE
+                .createContainer(Collections.emptyList());
+        rc.run(() -> {
+            assertListEQ(Collections.singletonList("attach"), rc.operations);
+        });
+        assertListEQ(Arrays.asList("attach", "detach"), rc.operations);
+
+        rc.operations.clear();
+        rc.run(() -> {
+            rc.run(() -> {
+                assertListEQ(Collections.singletonList("attach"), rc.operations);
+            });
+        });
+        assertListEQ(Arrays.asList("attach", "detach"), rc.operations);
+
+        rc.operations.clear();
+        rc.run(() -> {
+            assertListEQ(Collections.singletonList("attach"), rc.operations);
+            ResourceContainer.root().run(() -> {
+                assertListEQ(Arrays.asList("attach", "detach"), rc.operations);
+            });
+        });
+        assertTrue(Arrays.asList("attach", "detach", "attach", "detach").equals(rc.operations));
+
+        rc.operations.clear();
+        rc.run(() -> {
+            assertListEQ(Collections.singletonList("attach"), rc.operations);
+            ResourceContainer.root().run(() -> {
+                rc.run(() -> {
+                    assertListEQ(Arrays.asList("attach", "detach", "attach"), rc.operations);
+                });
+            });
+        });
+        assertTrue(Arrays.asList("attach", "detach", "attach", "detach", "attach", "detach").equals(rc.operations));
+    }
+
+    private static void assertListEQ(List<String> lhs, List<String> rhs) {
+        assertTrue(lhs.equals(rhs), "expect " + lhs + " equals to " + rhs);
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestState.java
+++ b/test/jdk/com/alibaba/rcm/TestState.java
@@ -1,0 +1,24 @@
+/*
+ * @test
+ * @summary Test get tenant state
+ * @library /test/lib
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main TestState
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import demo.MyResourceFactory;
+
+import java.util.Collections;
+
+import static jdk.test.lib.Asserts.*;
+
+
+public class TestState {
+    public static void main(String[] args) {
+        ResourceContainer rc = MyResourceFactory.INSTANCE.createContainer(Collections.emptyList());
+        assertEQ(rc.getState(), ResourceContainer.State.RUNNING);
+        rc.destroy();
+        assertEQ(rc.getState(), ResourceContainer.State.DEAD);
+    }
+}

--- a/test/jdk/com/alibaba/rcm/TestSwitchBetweenContainers.java
+++ b/test/jdk/com/alibaba/rcm/TestSwitchBetweenContainers.java
@@ -1,0 +1,42 @@
+/*
+ * @test
+ * @summary Test switch between containers
+ * @library /test/lib
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main TestSkeletalAttach
+ */
+
+import com.alibaba.rcm.ResourceContainer;
+import demo.MyResourceFactory;
+
+import java.util.Collections;
+
+import static jdk.test.lib.Asserts.*;
+
+
+public class TestSwitchBetweenContainers {
+
+    public static void main(String[] args) {
+        ResourceContainer rc1 = MyResourceFactory.INSTANCE.createContainer(Collections.emptyList());
+        ResourceContainer rc2 = MyResourceFactory.INSTANCE.createContainer(Collections.emptyList());
+
+        boolean hasIllegalStateException = false;
+
+        try {
+            rc1.run(() -> {
+                rc2.run(() -> {
+                });
+            });
+        } catch (IllegalStateException e) {
+            hasIllegalStateException = true;
+        }
+        assertTrue(hasIllegalStateException);
+        rc1.run(() -> {
+            ResourceContainer.root().run(() -> {
+                rc2.run(() -> {
+                });
+            });
+        });
+    }
+
+}

--- a/test/jdk/com/alibaba/rcm/demo/MyResourceContainer.java
+++ b/test/jdk/com/alibaba/rcm/demo/MyResourceContainer.java
@@ -1,0 +1,46 @@
+package demo;
+
+import com.alibaba.rcm.Constraint;
+import com.alibaba.rcm.internal.AbstractResourceContainer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MyResourceContainer extends AbstractResourceContainer {
+
+    public List<String> operations = new ArrayList<>();
+
+    private boolean dead;
+
+    @Override
+    protected void attach() {
+        super.attach();
+        operations.add("attach");
+    }
+
+    @Override
+    protected void detach() {
+        super.detach();
+        operations.add("detach");
+    }
+
+    @Override
+    public State getState() {
+        return dead ? State.DEAD : State.RUNNING;
+    }
+
+    @Override
+    public void updateConstraint(Constraint constraint) {
+        operations.add("update " + constraint.getResourceType());
+    }
+
+    @Override
+    public Iterable<Constraint> getConstraints() {
+        return null;
+    }
+
+    @Override
+    public void destroy() {
+        dead = true;
+    }
+}

--- a/test/jdk/com/alibaba/rcm/demo/MyResourceFactory.java
+++ b/test/jdk/com/alibaba/rcm/demo/MyResourceFactory.java
@@ -1,0 +1,21 @@
+package demo;
+
+import com.alibaba.rcm.Constraint;
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceContainerFactory;
+
+public class MyResourceFactory implements ResourceContainerFactory {
+
+    public final static ResourceContainerFactory INSTANCE = new MyResourceFactory();
+
+    private MyResourceFactory() { /*pass*/}
+
+    @Override
+    public ResourceContainer createContainer(Iterable<Constraint> constraints) {
+        MyResourceContainer container = new MyResourceContainer();
+        for (Constraint constraint : constraints) {
+            container.updateConstraint(constraint);
+        }
+        return container;
+    }
+}

--- a/test/jdk/com/alibaba/rcm/demo/MyResourceType.java
+++ b/test/jdk/com/alibaba/rcm/demo/MyResourceType.java
@@ -1,0 +1,12 @@
+package demo;
+
+import com.alibaba.rcm.ResourceType;
+
+public class MyResourceType extends ResourceType {
+    public final static ResourceType MY_RESOURCE1 = new MyResourceType("MY_RESOURCE1");
+    public final static ResourceType MY_RESOURCE2 = new MyResourceType("MY_RESOURCE2");
+
+    public MyResourceType(String name) {
+        super(name);
+    }
+}

--- a/test/jdk/com/alibaba/rcm/demo/RCInheritedThreadFactory.java
+++ b/test/jdk/com/alibaba/rcm/demo/RCInheritedThreadFactory.java
@@ -1,0 +1,24 @@
+package demo;
+
+import com.alibaba.rcm.internal.AbstractResourceContainer;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.JavaLangAccess;
+
+import java.util.concurrent.ThreadFactory;
+
+public class RCInheritedThreadFactory implements ThreadFactory {
+    public final static ThreadFactory INSTANCE = new RCInheritedThreadFactory();
+    private final static JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
+    @Override
+    public Thread newThread(Runnable r) {
+        return new Thread(() -> {
+            AbstractResourceContainer irc = JLA.getInheritedResourceContainer(Thread.currentThread());
+            if (irc != null) {
+                irc.run(r);
+            } else {
+                r.run();
+            }
+        });
+    }
+}

--- a/test/jdk/com/alibaba/wisp/bug/TestInvokeDynamicInterruption.java
+++ b/test/jdk/com/alibaba/wisp/bug/TestInvokeDynamicInterruption.java
@@ -1,0 +1,111 @@
+/*
+ * @test
+ * @summary Test invoke dynamic class for lambda with interrupt
+ * @modules java.base/jdk.internal.access
+ * @library /test/lib
+ * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableHandOff=false -XX:+AllowParallelDefineClass TestInvokeDynamicInterruption
+*/
+import com.alibaba.wisp.engine.WispEngine;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static jdk.test.lib.Asserts.assertFalse;
+
+public class TestInvokeDynamicInterruption {
+    private final static AtomicInteger idGenerator = new AtomicInteger();
+    static WispEngine executor;
+    static WispEngine executor2;
+    static Thread[] threads;
+    static CountDownLatch[] finishLatchs;
+    static CountDownLatch finishLatch;
+    static boolean is_interrupted = false;
+
+    public static void main(String[] args) throws Exception {
+        testInvokeDynamic();
+    }
+
+    private static void testInvokeDynamic() throws Exception {
+        threads = new Thread[2];
+        executor = WispEngine.createEngine(4, new ThreadFactory() {
+            AtomicInteger seq = new AtomicInteger();
+
+            @Override
+            public Thread newThread(Runnable r) {
+                int index = seq.getAndIncrement();
+                Thread t = new Thread(r, "Wisp2-Group-Test-Carrier-" + index);
+                t.setDaemon(true);
+                return t;
+            }
+        });
+
+        executor2 = WispEngine.createEngine(4, new ThreadFactory() {
+            AtomicInteger seq = new AtomicInteger();
+
+            @Override
+            public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "Wisp2-Group-Test2-Carrier-" + seq.getAndIncrement());
+                t.setDaemon(true);
+                return t;
+            }
+        });
+
+        finishLatchs = new CountDownLatch[2];
+        for (int j = 0; j < 2; ++j) {
+            finishLatchs[j] = new CountDownLatch(1);
+        }
+        finishLatch = new CountDownLatch(2);
+
+        Thread.sleep(100);
+        for (int j = 0; j < 2; ++j) {
+            executor.execute(() -> {
+                try {
+                    int id = idGenerator.getAndIncrement();
+                    System.out.println("id = " + id);
+                    threads[id] = Thread.currentThread();
+                    finishLatchs[id].countDown();
+                    executor.execute(() -> {
+                        try {
+                            List<Integer> list = Arrays.asList(1,2,3,4,5,6,7);
+                            int sum = list.stream().map(x -> x*x).reduce((x,y) -> x + y).get();
+                            System.out.println("after invoke " + sum);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                            is_interrupted = true;
+                        } finally {
+                            finishLatch.countDown();
+                        }
+                    });
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    System.exit(-1);
+                }
+            });
+        }
+        for (int j = 0; j < 2; ++j) {
+            final int index = 1 - j;
+            executor2.execute(() -> {
+                try {
+                    finishLatchs[index].await();
+                    for (int i = 0; i < 10; ++i) {
+                        decIt(i);
+                    }
+
+                    threads[index].interrupt();
+                    System.out.println("interrupt thread " + index);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        finishLatch.await();
+        assertFalse(is_interrupted);
+    }
+
+    private static void decIt(long num) {
+        while (0 != num--);
+    }
+}

--- a/test/jdk/com/alibaba/wisp/bug/TestWispSocketLeakWhenConnectTimeout.java
+++ b/test/jdk/com/alibaba/wisp/bug/TestWispSocketLeakWhenConnectTimeout.java
@@ -3,39 +3,21 @@
  * @library /test/lib
  * @summary test the fix to fd leakage when socket connect timeout
  * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true TestWispSocketLeakWhenConnectTimeout
-*/
+ */
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.util.Properties;
 
 import static jdk.test.lib.Asserts.assertTrue;
 
 public class TestWispSocketLeakWhenConnectTimeout {
-
-    static Properties p;
-    static String socketAddr;
-    static {
-        p = java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<Properties>() {
-                    public Properties run() {
-                        return System.getProperties();
-                    }
-                }
-        );
-        socketAddr = (String)p.get("test.wisp.socketAddress");
-        if (socketAddr == null) {
-            socketAddr = "www.example.com";
-        }
-    }
-
     public static void main(String[] args) throws IOException {
         Socket so = new Socket();
         boolean timeout = false;
         try {
-            so.connect(new InetSocketAddress(socketAddr, 80), 5);
+            so.connect(new InetSocketAddress("www.example.com", 80), 5);
         } catch (SocketTimeoutException e) {
             assertTrue(so.isClosed());
             timeout = true;

--- a/test/jdk/com/alibaba/wisp/timer/TestPriorityQueueSort.java
+++ b/test/jdk/com/alibaba/wisp/timer/TestPriorityQueueSort.java
@@ -18,114 +18,133 @@ import static jdk.test.lib.Asserts.assertTrue;
 
 public class TestPriorityQueueSort {
 
-	static Class<?> classQ;
-	static Class<?> classT;
+    static Class<?> classQ;
+    static Class<?> classT;
 
-	static Method poll = null;
-	static Method offer = null;
+    static Method poll = null;
+    static Method offer = null;
 
-	static TimeOut ILLEGAL_FLAG = new TimeOut(null, 1, false);
+    static Class<TimeOut> clazz;
+    static Constructor<TimeOut> constructor;
 
-	static class MyComparator implements Comparator<TimeOut> {
-		public int compare(TimeOut x, TimeOut y) {
-			return Long.compare(getDeadNano(x), getDeadNano(y));
-		}
-	}
+    static {
+        try {
+            clazz = (Class<TimeOut>) Class.forName("com.alibaba.wisp.engine.TimeOut");
+            constructor = clazz.getDeclaredConstructor(Class.forName("com.alibaba.wisp.engine.WispTask"), long.class,
+                    Class.forName("com.alibaba.wisp.engine.TimeOut$Action"));
+            ILLEGAL_FLAG = constructor.newInstance(null, 1,
+                    Class.forName("com.alibaba.wisp.engine.TimeOut$Action").getEnumConstants()[1]);
+        } catch (Exception e) {
+            assertTrue(false, e.toString());
+        }
+    }
 
-	static Long getDeadNano(TimeOut t) {
-		try {
-			Field deadline = TimeOut.class.getDeclaredField("deadlineNano");
-			deadline.setAccessible(true);
-			return (Long) deadline.get(t);
-		} catch (Exception e) {
-			throw new Error(e);
-		}
-	}
+    static TimeOut ILLEGAL_FLAG;
 
-	static Object getTimerQueue() {
-		try {
-			classQ = Class.forName("com.alibaba.wisp.engine.TimeOut$TimerManager$Queue");
-			classT = Class.forName("com.alibaba.wisp.engine.TimeOut$TimerManager");
-			Constructor c1 = classQ.getDeclaredConstructor(classT);
-			c1.setAccessible(true);
-			Constructor c2 = classT.getDeclaredConstructor();
-			c2.setAccessible(true);
-			poll = classQ.getDeclaredMethod("poll");
-			poll.setAccessible(true);
-			offer = classQ.getDeclaredMethod("offer", TimeOut.class);
-			offer.setAccessible(true);
-			return c1.newInstance(c2.newInstance());
-		} catch (Exception e) {
-			e.printStackTrace();
-			return null;
-		}
-	}
+    static class MyComparator implements Comparator<TimeOut> {
+        public int compare(TimeOut x, TimeOut y) {
+            return Long.compare(getDeadNano(x), getDeadNano(y));
+        }
+    }
 
-	static boolean add(Object pq, TimeOut timeOut) {
-		try {
-			offer.invoke(pq, timeOut);
-			return true;
-		} catch (Exception e) {
-			e.printStackTrace();
-			return false;
-		}
-	}
+    static Long getDeadNano(TimeOut t) {
+        try {
+            Field deadline = TimeOut.class.getDeclaredField("deadlineNano");
+            deadline.setAccessible(true);
+            return (Long) deadline.get(t);
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
 
-	static TimeOut poll(Object pq) {
-		try {
-			return (TimeOut)poll.invoke(pq);
-		} catch (Exception e) {
-			e.printStackTrace();
-			return ILLEGAL_FLAG;
-		}
-	}
+    static Object getTimerQueue() {
+        try {
+            classQ = Class.forName("com.alibaba.wisp.engine.TimeOut$TimerManager$Queue");
+            classT = Class.forName("com.alibaba.wisp.engine.TimeOut$TimerManager");
+            Constructor c1 = classQ.getDeclaredConstructor(classT);
+            c1.setAccessible(true);
+            Constructor c2 = classT.getDeclaredConstructor();
+            c2.setAccessible(true);
+            poll = classQ.getDeclaredMethod("poll");
+            poll.setAccessible(true);
+            offer = classQ.getDeclaredMethod("offer", TimeOut.class);
+            offer.setAccessible(true);
+            return c1.newInstance(c2.newInstance());
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 
-	public static void main(String[] args) {
-		int n = 10000;
+    static boolean add(Object pq, TimeOut timeOut) {
+        try {
+            offer.invoke(pq, timeOut);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
 
-		List<Long> sorted = new ArrayList<>(n);
-		for (int i = 0; i < n; i++)
-			sorted.add(new Long(i));
-		List<Long> shuffled = new ArrayList<>(sorted);
-		Collections.shuffle(shuffled);
+    static TimeOut poll(Object pq) {
+        try {
+            return (TimeOut) poll.invoke(pq);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ILLEGAL_FLAG;
+        }
+    }
 
-		Object pq = getTimerQueue();
+    public static void main(String[] args) {
+        int n = 10000;
 
+        List<Long> sorted = new ArrayList<>(n);
+        for (int i = 0; i < n; i++)
+            sorted.add(new Long(i));
+        List<Long> shuffled = new ArrayList<>(sorted);
+        Collections.shuffle(shuffled);
 
-		for (Iterator<Long> i = shuffled.iterator(); i.hasNext(); )
-			add(pq, new TimeOut(null, i.next(), false));
+        Object pq = getTimerQueue();
 
-		List<Long> recons = new ArrayList<>();
+        try {
+            for (Iterator<Long> i = shuffled.iterator(); i.hasNext();)
+                add(pq, constructor.newInstance(null, i.next(),
+                        Class.forName("com.alibaba.wisp.engine.TimeOut$Action").getEnumConstants()[1]));
 
-		while (true) {
-			TimeOut t = poll(pq);
-			if (t == null) {
-				break;
-			}
-			recons.add(getDeadNano(t));
-		}
-		assertTrue(recons.equals(sorted), "Sort failed");
+            List<Long> recons = new ArrayList<>();
+            while (true) {
+                TimeOut t = poll(pq);
+                if (t == null) {
+                    break;
+                }
+                recons.add(getDeadNano(t));
+            }
+            assertTrue(recons.equals(sorted), "Sort failed");
 
-		for (Long val : recons) {
-			add(pq, new TimeOut(null, val, false));
-		}
-		recons.clear();
-		while(true){
-			TimeOut timeOut = poll(pq);
-			if (timeOut == null) {
-				break;
-			}
-			if(getDeadNano(timeOut)  % 2 == 1) {
-				recons.add(getDeadNano(timeOut));
-			}
-		}
+            for (Long val : recons) {
+                add(pq, constructor.newInstance(null, val,
+                        Class.forName("com.alibaba.wisp.engine.TimeOut$Action").getEnumConstants()[1]));
+            }
+            recons.clear();
+            while (true) {
+                TimeOut timeOut = poll(pq);
+                if (timeOut == null) {
+                    break;
+                }
+                if (getDeadNano(timeOut) % 2 == 1) {
+                    recons.add(getDeadNano(timeOut));
+                }
+            }
 
-		Collections.sort(recons);
+            Collections.sort(recons);
 
-		for (Iterator<Long> i = sorted.iterator(); i.hasNext(); )
-			if ((i.next().intValue() % 2) != 1)
-				i.remove();
+            for (Iterator<Long> i = sorted.iterator(); i.hasNext();)
+                if ((i.next().intValue() % 2) != 1)
+                    i.remove();
 
-		assertTrue(recons.equals(sorted), "Odd Sort failed");
-	}
+            assertTrue(recons.equals(sorted), "Odd Sort failed");
+        } catch (Exception e) {
+            assertTrue(false, e.toString());
+        }
+    }
 }

--- a/test/jdk/com/alibaba/wisp2/TestWispMultiThreadExecutor.java
+++ b/test/jdk/com/alibaba/wisp2/TestWispMultiThreadExecutor.java
@@ -1,0 +1,134 @@
+/*
+ * @test
+ * @summary Test WispCounter using by WispMultiThreadExecutor
+ * @library /test/lib
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @run main/othervm -XX:+EnableCoroutine  -Dcom.alibaba.wisp.profile=true -Dcom.alibaba.wisp.transparentWispSwitch=true -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableHandOff=false  TestWispMultiThreadExecutor
+ * @run main/othervm -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableHandOff=false  TestWispMultiThreadExecutor
+*/
+
+import com.alibaba.wisp.engine.WispEngine;
+import com.alibaba.management.WispCounterData;
+import com.alibaba.management.WispCounterMXBean;
+
+import javax.management.MBeanServer;
+import java.io.*;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.alibaba.wisp.engine.WispEngine;
+import jdk.internal.access.SharedSecrets;
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class TestWispMultiThreadExecutor {
+    static WispMultiThreadExecutor executor;
+    static WispCounterMXBean mbean;
+    static Method counterMethod;
+    static boolean isNewJdk;
+    public static void main(String[] args) throws Exception {
+
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        try {
+            mbean = ManagementFactory.newPlatformMXBeanProxy(mbs,
+                    "com.alibaba.management:type=WispCounter", WispCounterMXBean.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        Method getCounter = WispCounterMXBean.class.getDeclaredMethod("getWispCounter", long.class);
+
+        if (getCounter.getReturnType() == WispCounterData.class) {
+            isNewJdk = true;
+        }
+        testWisp2Group();
+    }
+
+    private static void testWisp2Group() throws Exception {
+        executor = new WispMultiThreadExecutor(4, new ThreadFactory() {
+            AtomicInteger seq = new AtomicInteger();
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "Wisp2-Group-Test-Carrier-" + seq.getAndIncrement());
+                t.setDaemon(true);
+                return t;
+            }
+        });
+        Thread.sleep(100);
+        for (int j = 0; j < 10; ++j) {
+            executor.execute(()-> {});
+        }
+        List<Boolean> list = mbean.getRunningStates();
+        System.out.println(list);
+        int size1 = list.size();
+        List<Long> list2 = mbean.getCreateTaskCount();
+        System.out.println(list2);
+        list2 = mbean.getExecutionCount();
+        System.out.println(list2);
+        List<Long> engines = executor.getWispEngines();
+        System.out.println(engines);
+        int count = 0;
+        for (Long id: engines) {
+            if (isNewJdk) {
+                WispCounterData data = mbean.getWispCounter(id);
+                if (data != null) {
+                    System.out.println(data.getExecutionCount());
+                }
+                count++;
+            }
+        }
+        assertTrue(count == 4);
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+        list = mbean.getRunningStates();
+        System.out.println(list);
+        int size2 = list.size();
+        assertTrue((size1 - size2) == 4);
+    }
+
+    static class WispMultiThreadExecutor extends AbstractExecutorService {
+        private final WispEngine delegated;
+        public WispMultiThreadExecutor(int threadCount, ThreadFactory threadFactory) {
+            delegated = WispEngine.createEngine(threadCount, threadFactory);
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            delegated.execute(command);
+        }
+
+        @Override
+        public void shutdown() {
+            delegated.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return null;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return delegated.awaitTermination(timeout, unit);
+        }
+
+        public List<Long> getWispEngines() {
+            return delegated.getWispCarrierIds();
+        }
+    }
+}


### PR DESCRIPTION
This patch contains 5 dragonwell11 patches.

Original patch url:
https://github.com/dragonwell-project/dragonwell11/commit/e61ea56579a8a46acbacfc3d947f4900d6a27874
https://github.com/dragonwell-project/dragonwell11/commit/34a96ec23e124a3aeb1209d6891864e65ff86421
https://github.com/dragonwell-project/dragonwell11/commit/0bf7278fe2c1821a0f6cb69da9927a787572c724
https://github.com/dragonwell-project/dragonwell11/commit/8dca88f5fcd8b856eb90da6f7f891ac2efc01eab
https://github.com/dragonwell-project/dragonwell11/commit/4834d0f180c63f3a08024d3d9735d9046e012a16

Test Plan: all wisp tests

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/131

---

[Wisp] Maintain consistency with AJDK8 for WispCounterMXBean
Summary:
For some users, use the same code on JDK8 and JDK11.
To maintain consistency with AJDK8 for WispCounterMXBean,
use the same function name to get the Counter information.

Test Plan:
test/jdk/com/alibaba/wisp2/TestWispMultiThreadExecutor.java

---

[Wisp] Port RCM and wisp patches
Summary: The change is to port RCM and wisp patches including:
- [Misc] Resource Management API
  https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/2468969
- [Wisp] Remove WispTask's parent field
  https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/2527125
- [Wisp] implement wisp task's cpu resource control
  https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/2405655
- [Misc] Polish rcm API
  https://code.aone.alibaba-inc.com/xcode/jdk8u_jdk/codereview/2682648

Test Plan: jtreg all wisp2 and rcm tests

---

[Wisp] bug fix for class loading with interrupt
Summary:
During class loading, it uses SystemDictMonitor for parallel
loading. With UseWispMonitor, it uses SystemDictObjMonitor instead
of SystemDictMonitor.

For SystemDictMonitor, wait operation can't be interrupted.
For SystemDictObjMonitor, it is implemented by object monitor and wait
operation can be interrupted. That causes an unexpected InterruptedException.

To fix the issue, change wait to waitUninterruptibly.

Test Plan:
test/jdk/com/alibaba/wisp/bug/TestInvokeDynamicInterruption.java
all wisp cases

---

[Wisp] Add RCM thread inheritance predicate
Summary: We need to verify thread's resource container inheritance
at run time to avoid lazy thread initialization causing unpreditable
thread stopping.Provided a callback for all users to predicate at
runtime.

Test Plan: jtreg TestRCMInheritance

---

[Wisp] Revert back TestWispSocketLeakWhenConnectTimeout.java
Summary: This test needs a timeout.

Test Plan: The test itself

---