### PR TITLE
[Wisp] WispControlGroup shutdown support.

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -1010,14 +1010,11 @@ JVM_ENTRY(jboolean, CoroutineSupport_stealCoroutine(JNIEnv* env, jclass klass, j
   return true;
 JVM_END
 
-JVM_ENTRY (void, CoroutineSupport_checkAndThrowException0(JNIEnv* env, jclass klass, jlong coroPtr))
+JVM_ENTRY (jboolean, CoroutineSupport_shouldThrowException0(JNIEnv* env, jclass klass, jlong coroPtr))
   assert(EnableCoroutine, "pre-condition");
   Coroutine* coro = (Coroutine*)coroPtr;
   assert(coro == thread->current_coroutine(), "invariant");
-  if (!coro->is_yielding() && coro->clinit_call_count() == 0) {
-    ThreadToNativeFromVM ttnfv(thread);
-    throw_new(env, "java/lang/ThreadDeath");
-  }
+  return !coro->is_yielding() && coro->clinit_call_count() == 0;
 JVM_END
 
 JVM_ENTRY (void, CoroutineSupport_printlnLockFree(JNIEnv* env, jclass klass, jstring info))
@@ -1142,7 +1139,7 @@ JNINativeMethod coroutine_support_methods[] = {
     {CC"moveCoroutine",           CC "(JJ)V",            FN_PTR(CoroutineSupport_moveCoroutine)},
     {CC"markThreadCoroutine",     CC "(J" COBA ")V",     FN_PTR(CoroutineSupport_markThreadCoroutine)},
     {CC"getCoroutineStack",       CC "(J)[" STE,         FN_PTR(CoroutineSupport_getCoroutineStack)},
-    {CC"checkAndThrowException0", CC "(J)V",             FN_PTR(CoroutineSupport_checkAndThrowException0)},
+    {CC"shouldThrowException0",   CC "(J)Z",             FN_PTR(CoroutineSupport_shouldThrowException0)},
     {CC"printlnLockFree",         CC "(" LANG "String;)V", FN_PTR(CoroutineSupport_printlnLockFree)},
 };
 

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -13,7 +13,6 @@ import java.nio.channels.SelectableChannel;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
@@ -122,10 +121,12 @@ public class WispEngine extends AbstractExecutorService {
             Class.forName(WispThreadWrapper.class.getName());
             Class.forName(TaskDispatcher.class.getName());
             Class.forName(StartShutdown.class.getName());
-            Class.forName(NotifyAndWaitTasksForShutdown.class.getName());
             Class.forName(Coroutine.StealResult.class.getName());
             Class.forName(ThreadAsWisp.class.getName());
             Class.forName(WispEventPump.class.getName());
+            Class.forName(ShutdownEngine.class.getName());
+            Class.forName(AbstractShutdownTask.class.getName());
+            Class.forName(ShutdownControlGroup.class.getName());
             if (WispConfiguration.WISP_PROFILE) {
                 Class.forName(WispPerfCounterMonitor.class.getName());
             }
@@ -336,7 +337,7 @@ public class WispEngine extends AbstractExecutorService {
     volatile int runningTaskCount = 0;
     private CountDownLatch shutdownFuture;
     volatile Boolean hasBeenShutdown = false;
-    volatile boolean detached;
+    volatile boolean terminated;
 
     /**
      * Create a new WispEngine for executing tasks.
@@ -353,7 +354,7 @@ public class WispEngine extends AbstractExecutorService {
      */
     private WispEngine(String name) {
         carrierEngines = new ConcurrentSkipListSet<>();
-        // detached carrier won't shut down
+        // terminated carrier won't shut down
         shutdownBarrier = null;
         scheduler = new WispScheduler(
                 WispConfiguration.WORKER_COUNT,
@@ -452,7 +453,11 @@ public class WispEngine extends AbstractExecutorService {
         for (WispCarrier carrier : carrierEngines) {
             deRegisterPerfCounter(carrier);
         }
-        scheduler.execute(new StartShutdown());
+        scheduler.execute(new StartShutdown(null));
+    }
+
+    void shutdown(WispControlGroup group) {
+        scheduler.execute(new StartShutdown(group));
     }
 
     @Override
@@ -460,67 +465,111 @@ public class WispEngine extends AbstractExecutorService {
         throw new UnsupportedOperationException();
     }
 
-    class StartShutdown extends StealDisabledRunnable {
+    class StartShutdown implements StealAwareRunnable {
+        private final WispControlGroup wispControlGroup;
+
+        /**
+         * @param wispControlGroup which WispControlGroup to shutdown,
+         *                         null indicates the whole engine.
+         */
+        StartShutdown(WispControlGroup wispControlGroup) {
+            this.wispControlGroup = wispControlGroup;
+        }
+
         @Override
         public void run() {
-            WispCarrier.current().runTaskInternal(new NotifyAndWaitTasksForShutdown(),
+            WispCarrier.current().runTaskInternal(
+                    wispControlGroup == null ? new ShutdownEngine() : new ShutdownControlGroup(wispControlGroup),
                     WispTask.SHUTDOWN_TASK_NAME, null, null);
         }
     }
 
-    class NotifyAndWaitTasksForShutdown implements Runnable {
+    abstract class AbstractShutdownTask implements StealAwareRunnable {
         @Override
         public void run() {
-            try {
-                // wait until current 'shutdown wispTask' is the only
-                // running wispTask on this carrier
-                while (runningTaskCount != 1) {
-                    List<WispTask> runningTasks = getRunningTasks();
-                    for (WispTask task : runningTasks) {
-                        if (task.carrier.engine == WispEngine.this
-                                && task.isAlive()
-                                && !WispTask.SHUTDOWN_TASK_NAME.equals(task.getName())) {
-                            task.interrupt();
-                        }
+            List<WispTask> tasks;
+            do {
+                tasks = getTasksForShutdown();
+                for (WispTask task : tasks) {
+                    if (task.isAlive()) {
+                        task.jdkUnpark();
+                        task.unpark();
                     }
-                    WispCarrier.current().yield();
                 }
-                assert WispTask.SHUTDOWN_TASK_NAME.equals(WispCarrier.current().current.getName());
-                detached = true;
-                //notify all worker to exit
-                for (WispCarrier carrier : carrierEngines) {
-                    carrier.worker.signal();
-                }
-                shutdownFuture.countDown();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+                // wait tasks to exit on fixed frequency instead of polling
+                WispTask.jdkPark(TimeUnit.MILLISECONDS.toNanos(1));
+            } while (!tasks.isEmpty());
+            finishShutdown();
         }
 
-        /**
-         * 1. In Wisp2, each WispCarrier's runningTask is modified when WispTask is stolen, we can't guarantee
-         * the accuracy of the task set.
-         * 2. this function is only called in shutdown, so it's not performance sensitive
-         * 3. this function should only be called by current WispTask
-         */
-        private List<WispTask> getRunningTasks() {
+        abstract List<WispTask> getTasksForShutdown();
+
+        abstract void finishShutdown();
+    }
+
+    class ShutdownEngine extends AbstractShutdownTask {
+        @Override
+        List<WispTask> getTasksForShutdown() {
+            return getRunningTasks(null);
+        }
+
+        @Override
+        void finishShutdown() {
             assert WispTask.SHUTDOWN_TASK_NAME.equals(WispCarrier.current().current.getName());
-            WispCarrier carrier = WispCarrier.current();
-            ArrayList<WispTask> runningTasks = new ArrayList<>();
-            boolean isInCritical0 = carrier.isInCritical;
-            carrier.isInCritical = true;
-            try {
-                for (WispTask task : WispTask.id2Task.values()) {
-                    if (task.isAlive()
-                            && task.carrier.engine == WispEngine.this
-                            && !task.isThreadTask()) {
-                        runningTasks.add(task);
-                    }
-                }
-                return runningTasks;
-            } finally {
-                carrier.isInCritical = isInCritical0;
+            terminated = true;
+            //notify all worker to exit
+            for (WispCarrier carrier : carrierEngines) {
+                carrier.worker.signal();
             }
+            shutdownFuture.countDown();
+        }
+
+    }
+
+    class ShutdownControlGroup extends AbstractShutdownTask {
+        private final WispControlGroup wispControlGroup;
+
+        ShutdownControlGroup(WispControlGroup wispControlGroup) {
+            this.wispControlGroup = wispControlGroup;
+        }
+        @Override
+        List<WispTask> getTasksForShutdown() {
+            return getRunningTasks(wispControlGroup);
+        }
+
+        @Override
+        void finishShutdown() {
+            wispControlGroup.destroyLatch.countDown();
+        }
+    }
+
+
+
+    /**
+     * 1. In Wisp2, each WispCarrier's runningTask is modified when WispTask is stolen, we can't guarantee
+     * the accuracy of the task set.
+     * 2. this function is only called in shutdown, so it's not performance sensitive
+     * 3. this function should only be called by current WispTask
+     */
+    private List<WispTask> getRunningTasks(WispControlGroup group) {
+        assert WispTask.SHUTDOWN_TASK_NAME.equals(WispCarrier.current().current.getName());
+        WispCarrier carrier = WispCarrier.current();
+        ArrayList<WispTask> runningTasks = new ArrayList<>();
+        boolean isInCritical0 = carrier.isInCritical;
+        carrier.isInCritical = true;
+        try {
+            for (WispTask task : WispTask.id2Task.values()) {
+                if (task.isAlive()
+                        && task.carrier.engine == WispEngine.this
+                        && !task.isThreadTask()
+                        && !task.getName().equals(WispTask.SHUTDOWN_TASK_NAME)
+                        && (group == null || task.inDestoryedGroup())) {
+                    runningTasks.add(task);
+                }
+            }
+            return runningTasks;
+        } finally {
+            carrier.isInCritical = isInCritical0;
         }
     }
 
@@ -531,7 +580,7 @@ public class WispEngine extends AbstractExecutorService {
 
     @Override
     public boolean isTerminated() {
-        return detached;
+        return terminated;
     }
 
     @Override
@@ -579,12 +628,6 @@ public class WispEngine extends AbstractExecutorService {
                 target, name, thread));
     }
 
-    abstract class StealDisabledRunnable implements StealAwareRunnable {
-        @Override
-        public final boolean isStealEnable() {
-            return false;
-        }
-    }
     private static native void registerNatives();
 
     private static native int getProxyUnpark(int[] res);

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispTask.java
@@ -227,7 +227,7 @@ public class WispTask implements Comparable<WispTask> {
                         throwable = t;
                     } finally {
                         assert timeOut == null;
-                        assert controlGroup == null; // detached
+                        assert controlGroup == null; // terminated
                         runnable = null;
                         WispEngine.JLA.setWispAlive(threadWrapper, false);
                         if (isThreadAsWisp) {
@@ -492,6 +492,10 @@ public class WispTask implements Comparable<WispTask> {
         }
         // return old interrupt status.
         return res;
+    }
+
+    boolean inDestoryedGroup() {
+        return controlGroup != null && controlGroup.destroyed;
     }
 
     @Override

--- a/src/java.base/share/classes/java/dyn/CoroutineSupport.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineSupport.java
@@ -102,9 +102,10 @@ public class CoroutineSupport {
     /**
      * check if we should throw a TenantDeath or ThreqadDeathException
      * @param coroutine the coroutine
+     * @return if coroutine should throw exception
      */
-    public static void checkAndThrowException(Coroutine coroutine) {
-        checkAndThrowException0(coroutine.nativeCoroutine);
+    public static boolean checkAndThrowException(Coroutine coroutine) {
+        return shouldThrowException0(coroutine.nativeCoroutine);
     }
 
 
@@ -431,5 +432,5 @@ public class CoroutineSupport {
 
     private static native boolean isInClinit0(long coroPtr);
 
-    private static native void checkAndThrowException0(long coroPtr);
+    private static native boolean shouldThrowException0(long coroPtr);
 }

--- a/test/jdk/com/alibaba/wisp2/TestWispControlGroupShutdown.java
+++ b/test/jdk/com/alibaba/wisp2/TestWispControlGroupShutdown.java
@@ -1,0 +1,99 @@
+/*
+ * @test
+ * @summary Verify wisp internal logic in a WispControlGroup container can be preempted
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @library /test/lib
+ * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=4 TestWispControlGroupShutdown
+ */
+
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.fail;
+
+public class TestWispControlGroupShutdown {
+    private static Runnable VOID_LOOP = () -> {
+        started = 1;
+        while (true) {
+        }
+    };
+
+    private static Runnable BUSY_LOOP = () -> {
+        started = 1;
+        while (true) {
+            int x;
+            do {
+                x = 1;
+            } while (x == 1);
+        }
+    };
+
+    private static Runnable PARK = () -> {
+        try {
+            started = 1;
+            new CountDownLatch(1).await();
+        } catch (InterruptedException e) {
+            fail();
+        }
+    };
+
+    private static volatile int started = 0;
+    private static AtomicBoolean flag = new AtomicBoolean(false);
+
+    private static Runnable FINALLY = () -> {
+        try {
+            started = 1;
+            new CountDownLatch(1).await();
+        } catch (Throwable e) {
+            assertTrue(e instanceof ThreadDeath);
+        } finally {
+            flag.set(true);
+        }
+    };
+
+    private static final List<Runnable> workload = new ArrayList<Runnable>() {{
+//        add(VOID_LOOP); TODO:// support  loop
+//        add(BUSY_LOOP);
+        add(PARK);
+        add(FINALLY);
+    }};
+
+    public static void main(String[] args) throws Exception {
+        for (Runnable runnable : workload) {
+            ExecutorService g = getControlGroup();
+            g.execute(runnable);
+            started = 0;
+            while (0 == started) {}
+            g.shutdown();
+            try {
+                assertTrue(g.awaitTermination(3, TimeUnit.SECONDS));
+            } catch (Exception e) {
+                e.printStackTrace();
+                fail();
+            }
+            System.out.println("PASS");
+        }
+        Thread.sleep(1000);
+        assertTrue(flag.get());
+    }
+
+    private static ExecutorService getControlGroup() {
+        try {
+            Class<?> WispControlGroupClazz = Class.forName("com.alibaba.wisp.engine.WispControlGroup");
+            Method createMethod = WispControlGroupClazz.getDeclaredMethod("newInstance", int.class);
+            createMethod.setAccessible(true);
+            return (ExecutorService) createMethod.invoke(null, 50);
+        } catch (Exception e) {
+           fail();
+        }
+        return  null;
+    }
+}


### PR DESCRIPTION
Summary: Add shutdown function in WispControlGroup, all tasks executed in responding group would throw ThreadDeath Exception and exit.

Test Plan: jtreg TestWispControlGroupShutdown

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/133