### PR TITLE
[Wisp] Add preempt check in interpreter.

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1191,6 +1191,9 @@ JRT_ENTRY(void, InterpreterRuntime::at_safepoint(JavaThread* current))
     LastFrameAccessor last_frame(current);
     JvmtiExport::at_single_stepping_point(current, last_frame.method(), last_frame.bcp());
   }
+  if (EnableCoroutine) {
+    Coroutine::after_safepoint(current);
+  }
 JRT_END
 
 JRT_LEAF(void, InterpreterRuntime::at_unwind(JavaThread* current))

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -378,6 +378,7 @@ private:
   static Method* parkMethod;
   static Method* unparkMethod;
   static Method* runOutsideWispMethod;
+  static Method* yieldMethod;
   static GrowableArray<int>* _proxy_unpark;
 
   Coroutine*  _coroutine;

--- a/test/hotspot/jtreg/runtime/coroutine/TestPreempt.java
+++ b/test/hotspot/jtreg/runtime/coroutine/TestPreempt.java
@@ -1,0 +1,42 @@
+/*
+ * @test
+ * @summary test wisp time slice preempt
+ * @library /test/lib
+ * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.carrierEngines=1 TestPreempt
+
+ */
+
+import com.alibaba.wisp.engine.WispEngine;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import static jdk.test.lib.Asserts.*;
+
+
+public class TestPreempt {
+    public static void main(String[] args) throws Exception {
+        doTest(TestPreempt::jniLoop);
+        doTest(TestPreempt::voidLoop);
+    }
+
+    private static void doTest(Runnable r) throws Exception {
+        WispEngine.dispatch(r);
+        CountDownLatch latch = new CountDownLatch(1);
+        WispEngine.dispatch(latch::countDown);
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+    }
+
+    private static void voidLoop() {
+        while (true) {}
+    }
+
+    private static void jniLoop() {
+        try {
+            while (true) { Thread.sleep(0);}
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+}


### PR DESCRIPTION
Summary: Preempt check could be left out when thread fall into interpreter or unhandled thread_state, this patch added check in interpreter and cleared preempted flag when needed.

Test Plan: jtreg TestPreempt.java

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/136