### PR TITLE
[Wisp] Fix error and crash in previous patches.

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -367,9 +367,9 @@ void MetaspaceShared::serialize(SerializeClosure* soc) {
 
 void MetaspaceShared::serialize_well_known_classes(SerializeClosure* soc) {
   if (EnableCoroutine) {
-    java_dyn_CoroutineBase::serialize(soc);
-    com_alibaba_wisp_engine_WispCarrier::serialize(soc);
-    com_alibaba_wisp_engine_WispTask::serialize(soc);
+    java_dyn_CoroutineBase::serialize_offsets(soc);
+    com_alibaba_wisp_engine_WispCarrier::serialize_offsets(soc);
+    com_alibaba_wisp_engine_WispTask::serialize_offsets(soc);
   }
 }
 

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4731,7 +4731,7 @@ void java_dyn_CoroutineBase::compute_offsets() {
 }
 
 #if INCLUDE_CDS
-void java_dyn_CoroutineBase::serialize(SerializeClosure* f) {
+void java_dyn_CoroutineBase::serialize_offsets(SerializeClosure* f) {
   COROUTINEBASE_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
 }
 #endif
@@ -4756,7 +4756,7 @@ void com_alibaba_wisp_engine_WispCarrier::compute_offsets() {
 }
 
 #if INCLUDE_CDS
-void com_alibaba_wisp_engine_WispCarrier::serialize(SerializeClosure* f) {
+void com_alibaba_wisp_engine_WispCarrier::serialize_offsets(SerializeClosure* f) {
   WISPENGINE_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
 }
 #endif
@@ -4793,7 +4793,7 @@ void com_alibaba_wisp_engine_WispTask::compute_offsets() {
 }
 
 #if INCLUDE_CDS
-void com_alibaba_wisp_engine_WispTask::serialize(SerializeClosure* f) {
+void com_alibaba_wisp_engine_WispTask::serialize_offsets(SerializeClosure* f) {
   WISPTASK_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
 }
 #endif
@@ -5177,11 +5177,7 @@ void java_lang_InternalError::serialize_offsets(SerializeClosure* f) {
 
 // Compute field offsets of all the classes in this file
 void JavaClasses::compute_offsets() {
-  if (EnableCoroutine) {
-    java_dyn_CoroutineBase::compute_offsets();
-    com_alibaba_wisp_engine_WispCarrier::compute_offsets();
-    com_alibaba_wisp_engine_WispTask::compute_offsets();
-  }
+  BASIC_JAVA_CLASSES_DO_PART_COROUTINE(DO_COMPUTE_OFFSETS);
 
   if (UseSharedSpaces) {
     JVMTI_ONLY(assert(JvmtiExport::is_early_phase() && !(JvmtiExport::should_post_class_file_load_hook() &&
@@ -5205,6 +5201,7 @@ void JavaClasses::compute_offsets() {
 
 void JavaClasses::serialize_offsets(SerializeClosure* soc) {
   BASIC_JAVA_CLASSES_DO(DO_SERIALIZE_OFFSETS);
+  BASIC_JAVA_CLASSES_DO_PART_COROUTINE(DO_SERIALIZE_OFFSETS);
 }
 #endif
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -81,6 +81,12 @@ class RecordComponent;
   f(vector_VectorPayload) \
   //end
 
+#define BASIC_JAVA_CLASSES_DO_PART_COROUTINE(f) \
+  f(java_dyn_CoroutineBase) \
+  f(com_alibaba_wisp_engine_WispCarrier) \
+  f(com_alibaba_wisp_engine_WispTask) \
+  //end
+
 #define BASIC_JAVA_CLASSES_DO(f) \
         BASIC_JAVA_CLASSES_DO_PART1(f) \
         BASIC_JAVA_CLASSES_DO_PART2(f)
@@ -1804,7 +1810,7 @@ public:
 
   static int get_native_coroutine_offset()    { return _native_coroutine_offset; }
 
-  static void serialize(SerializeClosure* f) NOT_CDS_RETURN;
+  static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 
   // Debugging
   friend class JavaClasses;
@@ -1817,7 +1823,7 @@ public:
   static bool in_critical(oop obj);
 
   static void compute_offsets();
-  static void serialize(SerializeClosure* f) NOT_CDS_RETURN;
+  static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 };
 
 class com_alibaba_wisp_engine_WispTask: AllStatic {
@@ -1846,7 +1852,7 @@ public:
   static void set_preemptCount(oop obj, jint count);
 
   static void compute_offsets();
-  static void serialize(SerializeClosure* f) NOT_CDS_RETURN;
+  static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 };
 
 // Interface to hard-coded offset checking

--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -995,16 +995,16 @@ void Coroutine::after_safepoint(JavaThread* thread) {
   assert(thread->thread_state() == origin_thread_state, "illegal thread state");
   coroutine->_is_yielding = false;
 
-  if (thread->has_pending_exception() 
-    && (thread->pending_exception()->klass() == vmClasses::OutOfMemoryError_klass()
-      || thread->pending_exception()->klass() == vmClasses::StackOverflowError_klass())) {
-      // throw expected vm error
-      return;
-  }
-
-  if (thread->has_pending_exception() || thread->has_async_exception_condition()) {
+  if (thread->has_pending_exception()) {
+    guarantee(thread->pending_exception()->klass() == vmClasses::OutOfMemoryError_klass() ||
+      thread->pending_exception()->klass() == vmClasses::StackOverflowError_klass() ||
+      thread->pending_exception()->klass() == vmClasses::ThreadDeath_klass(),
+      "Only SOF/OOM/ThreadDeath happens here");
+    // If it's a SOF / OOM / ThreadDeath exception, we'd clear it
+    // because polling page stub shouldn't have a pending exception.
     thread->clear_pending_exception();
   }
+
 }
 
 EnableStealMark::EnableStealMark(Thread* thread) {

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -977,6 +977,13 @@ void ThreadSafepointState::handle_polling_page_exception() {
     SafepointMechanism::process_if_requested_with_exit_check(self, false /* check asyncs */);
     set_at_poll_safepoint(false);
 
+    if (EnableCoroutine) {
+      // we should move this logic forward, to make sure
+      // the sanity check of pending/pending async ex
+      // check is effective for this java call.
+      Coroutine::after_safepoint(thread());
+    }
+
     // If we have a pending async exception deoptimize the frame
     // as otherwise we may never deliver it.
     if (self->has_async_exception_condition()) {
@@ -1000,9 +1007,6 @@ void ThreadSafepointState::handle_polling_page_exception() {
 
         fatal("Exception installed and deoptimization is pending");
       }
-    }
-    if (EnableCoroutine) {
-      Coroutine::after_safepoint(thread());
     }
   }
 }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2407,6 +2407,10 @@ void JavaThread::prepare(jobject jni_thread, ThreadPriority prio) {
   Threads::add(this);
 }
 
+ThreadStatistics* JavaThread::get_thread_stat() const {
+  return UseWispMonitor ? WispThread::current(const_cast<JavaThread*>(this))->_thread_stat : _thread_stat;
+}
+
 oop JavaThread::current_park_blocker() {
   // Support for JSR-166 locks
   oop thread_oop = threadObj();

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1606,7 +1606,7 @@ class JavaThread: public Thread {
   ThreadStatistics *_thread_stat;
 
  public:
-  ThreadStatistics* get_thread_stat() const    { return _thread_stat; }
+  ThreadStatistics* get_thread_stat() const;
 
   // Return a blocker object for which this thread is blocked parking.
   oop current_park_blocker();

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispCarrier.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispCarrier.java
@@ -229,7 +229,7 @@ final class WispCarrier implements Comparable<WispCarrier> {
     }
 
     private void checkAndDispatchShutdown() {
-        assert WispCarrier.current() == this;
+        WispTask current = WispCarrier.current().getCurrentTask();
         if ((engine.hasBeenShutdown
                 || (current.inDestoryedGroup() && current.inheritedFromNonRootContainer()))
                 && !WispTask.SHUTDOWN_TASK_NAME.equals(current.getName())

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -797,7 +797,7 @@ public class ServerSocket implements java.io.Closeable {
      * @since 1.4
      */
     public ServerSocketChannel getChannel() {
-        return WispEngine.transparentWispSwitch() ? asyncImpl.getChannel() : null;
+        return null;
     }
 
     /**

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -948,7 +948,7 @@ public class Socket implements java.io.Closeable {
      * @since 1.4
      */
     public SocketChannel getChannel() {
-        return WispEngine.transparentWispSwitch() ? asyncImpl.getChannel() : null;
+        return null;
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/WispServerSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/WispServerSocketImpl.java
@@ -15,9 +15,9 @@ import java.util.concurrent.TimeUnit;
 
 public class WispServerSocketImpl
 {
-    private static WispEngineAccess WEA = SharedSecrets.getWispEngineAccess();
+    private static final WispEngineAccess WEA = SharedSecrets.getWispEngineAccess();
 
-    private WispSocketLockSupport wispSocketLockSupport = new WispSocketLockSupport();
+    private final WispSocketLockSupport wispSocketLockSupport = new WispSocketLockSupport();
     // The channel being adapted
     private ServerSocketChannelImpl ssc = null;
 
@@ -98,10 +98,6 @@ public class WispServerSocketImpl
             ssc.close();
             wispSocketLockSupport.unparkBlockedWispTask();
         }
-    }
-
-    public ServerSocketChannel getChannel() {
-        return ssc;
     }
 
     public boolean isBound() {

--- a/src/java.base/share/classes/sun/nio/ch/WispSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/WispSocketImpl.java
@@ -19,13 +19,13 @@ import java.util.concurrent.TimeUnit;
 
 public class WispSocketImpl
 {
-    private static WispEngineAccess WEA = SharedSecrets.getWispEngineAccess();
+    private static final WispEngineAccess WEA = SharedSecrets.getWispEngineAccess();
 
-    WispSocketLockSupport wispSocketLockSupport = new WispSocketLockSupport();
+    private final WispSocketLockSupport wispSocketLockSupport = new WispSocketLockSupport();
     // The channel being adapted
     private SocketChannelImpl sc = null;
     // 1 verse 1 related socket
-    private Socket so;
+    private final Socket so;
     // Timeout "option" value for reads
     protected int timeout = 0;
     private InputStream socketInputStream = null;
@@ -37,10 +37,6 @@ public class WispSocketImpl
     public WispSocketImpl(SocketChannel sc, Socket so) {
         this.so = so;
         this.sc = (SocketChannelImpl) sc;
-    }
-
-    public SocketChannel getChannel() {
-        return sc;
     }
 
     // Override this method just to protect against changes in the superclass

--- a/test/jdk/com/alibaba/wisp/io/TestDatagramSocket.java
+++ b/test/jdk/com/alibaba/wisp/io/TestDatagramSocket.java
@@ -3,7 +3,7 @@
  * @library /test/lib
  * @summary Test WispEngine's DatagramSocket, InitialDirContext use dup socket to query dns.
  * @modules java.base/jdk.internal.access
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true TestDatagramSocket
+ * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true TestDatagramSocket
 */
 
 

--- a/test/jdk/com/alibaba/wisp/io/TestGlobalPoller.java
+++ b/test/jdk/com/alibaba/wisp/io/TestGlobalPoller.java
@@ -13,30 +13,28 @@ import com.alibaba.wisp.engine.WispTask;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.WispEngineAccess;
 import sun.nio.ch.SelChImpl;
+import sun.nio.ch.WispSocketImpl;
 
 import java.lang.reflect.Field;
 import java.net.Socket;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.security.PrivilegedAction;
 import java.util.Properties;
 
 import static jdk.test.lib.Asserts.assertTrue;
 import static jdk.test.lib.Asserts.assertNotNull;
 
 public class TestGlobalPoller {
-    private static WispEngineAccess access = SharedSecrets.getWispEngineAccess();
+    private static final WispEngineAccess access = SharedSecrets.getWispEngineAccess();
 
     static Properties p;
     static String socketAddr;
     static {
         p = java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<Properties>() {
-                    public Properties run() {
-                        return System.getProperties();
-                    }
-                }
+                (PrivilegedAction<Properties>) System::getProperties
         );
-        socketAddr = (String)p.get("test.wisp.socketAddress");
+        socketAddr = (String) p.get("test.wisp.socketAddress");
         if (socketAddr == null) {
             socketAddr = "www.example.com";
         }
@@ -50,7 +48,7 @@ public class TestGlobalPoller {
         // now server returns the data..
         // so is readable
         // current task is interested in read event.
-        SocketChannel ch = so.getChannel();
+        SocketChannel ch = getCh(so);
         access.registerEvent(ch, SelectionKey.OP_READ);
 
         Class<?> clazz = Class.forName("com.alibaba.wisp.engine.WispEventPump$Pool");
@@ -74,5 +72,14 @@ public class TestGlobalPoller {
         assertTrue(fd2TaskLow[fd] == null);
 
         so.close();
+    }
+
+    private static SocketChannel getCh(Socket so) throws Exception {
+        Field f = Socket.class.getDeclaredField("asyncImpl");
+        f.setAccessible(true);
+        WispSocketImpl wispSocket = (WispSocketImpl) f.get(so);
+        f = wispSocket.getClass().getDeclaredField("sc");
+        f.setAccessible(true);
+        return (SocketChannel) f.get(wispSocket);
     }
 }

--- a/test/jdk/com/alibaba/wisp/thread/TestPreempt.java
+++ b/test/jdk/com/alibaba/wisp/thread/TestPreempt.java
@@ -17,14 +17,20 @@ import static jdk.test.lib.Asserts.assertTrue;
 
 public class TestPreempt {
     public static void main(String[] args) throws Exception {
-        doTest(TestPreempt::simpleLoop);
+        doTest(TestPreempt::simpleLoop, true);
+        for (int i = 0; i < 15; i++) {
+            doTest(() -> stackTrace(0), false);  // only test sanity: don't crash
+        }
     }
 
-    private static void doTest(Runnable r) throws Exception {
+    private static void doTest(Runnable r, boolean checkAssert) throws Exception {
         WispEngine.dispatch(r);
         CountDownLatch latch = new CountDownLatch(1);
         WispEngine.dispatch(latch::countDown);
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        boolean success = latch.await(5, TimeUnit.SECONDS);
+        if (checkAssert) {
+            assertTrue(success);
+        }
     }
 
     private static void complexLoop() {
@@ -46,6 +52,17 @@ public class TestPreempt {
         do {
             x = n;
         } while (x == n);
+    }
+
+    private static void stackTrace(int i) {
+        if (i == 10000) {
+            int x;
+            do {
+                x = n;
+            } while (x == n);
+        } else {
+            stackTrace(i + 1);
+        }
     }
 
     // TODO: handle safepoint consumed by state switch

--- a/test/jdk/com/alibaba/wisp2/SocketGetChannelTest.java
+++ b/test/jdk/com/alibaba/wisp2/SocketGetChannelTest.java
@@ -1,0 +1,26 @@
+/*
+ * @test
+ * @library /test/lib
+ * @summary test Socket.getChannel returns null
+ * @requires os.family == "linux"
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @run main SocketGetChannelTest
+ * @run main/othervm -XX:+UseWisp2 SocketGetChannelTest
+ */
+
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import static jdk.test.lib.Asserts.assertNull;
+
+public class SocketGetChannelTest {
+    public static void main(String[] args) throws Exception {
+        ServerSocket ss = new ServerSocket(0);
+        Socket s1 = new Socket("localhost", ss.getLocalPort());
+        Socket s2 = ss.accept();
+        assertNull(ss.getChannel());
+        assertNull(s1.getChannel());
+        assertNull(s2.getChannel());
+    }
+}


### PR DESCRIPTION
This patch contains 5 dragonwell11 patches.

Original patch url:
https://github.com/dragonwell-project/dragonwell11/commit/6fa2527983e4ef60a0a126af12458b251bb1e6d8
https://github.com/dragonwell-project/dragonwell11/commit/4dce4d8613362eeeab165edd7d6e160faf1df09a
https://github.com/dragonwell-project/dragonwell11/commit/701890560a56360796f95984254a2327fcf75ace
https://github.com/dragonwell-project/dragonwell11/commit/393e3b43fe92181e3fe26086d1d042db8c59bc40
https://github.com/dragonwell-project/dragonwell11/commit/b56e4b8b20b47cdb21d6239cc51232fa48b56bec

Test Plan: all wisp tests

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/140

---

[Wisp] Get the correct _thread_stat in Coroutine
Summary: We get the wrong _thread_stat in wisp, which will make PerfCounter not precise and may cause an assert error as well.

Test Plan: test/jdk/com/alibaba/wisp/io/TestDatagramSocket.java with -XX:+UseWispMonitor, and other tests

---

[Wisp] Clear pending exceptions of SOF/OOM when polling happens
Summary: If a polling page happens in an OSR method which optimized the rethrow handler in C2-compiled method, and in the mean time a wisp preempt happens and throws an SOF/OOM exception, jvm will crash. We directly clear the pending ex to fix this "MISSING EXCEPTION HANDLER" problem.

Test Plan: TestPreempt.java

---

[Wisp] Dump coroutine classes offsets for CDS by default
Summary: If classes.jsa is not generated with EnableCoroutine option, it can not be used by Wisp (which will throw an error). By default a classes.jsa will be generated in <JAVA_HOME>/lib/server folder, so we need to dump coroutine classes offsets by default.

Test Plan: all Wisp tests and all CDS tests

---

[Wisp] Fix wrong assert
Summary: WispTask could be moved between carriers during
yield, so should refetch current task.

Test Plan: com/alibaba/wisp

---

[Wisp] Socket.getChannel() should return null
Summary:
Changing the return value of Socket.getChannel() will affect the
correctness of some libraries. For example, Apache geode tests whether
it is a nio adaptor channel through the return value of getChannel().

Test Plan: SocketGetChannelTest

---