### PR TITLE
[Wisp] Thread as Wisp whitelist and Fix dead loop when killing threads waiting for objectmonitor.

### DIFF
--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -735,6 +735,15 @@ void WispThread::park(long millis, const ObjectWaiter* ow) {
   JavaThread* jt = ((WispThread*) ow->_thread)->thread();
   assert(jt == Thread::current(), "current");
 
+  assert (!jt->has_pending_exception(), "should not have any pending exception");
+  if (jt->has_async_exception_condition()) {
+    assert(UseWisp2 && Wisp2ThreadStop, "pre-condition");
+    assert(jt->has_aync_thread_death_exception(), "must be wisp_thread_death_exception");
+    // JavaCalls will be skipped if current thread has a pending exception
+    // mannually clear all async exceptions before calling into java
+    jt->clear_aync_thread_death_exception();
+  }
+
   if (ow->_timeout > 0) {
     millis = ow->_timeout;
     assert(!ow->_using_wisp_park, "invariant");
@@ -819,6 +828,14 @@ void WispThread::unpark(int task_id, bool using_wisp_park, bool proxy_unpark, Pa
     Wisp_lock->notify(); // only one consumer
     wisp_thread->_unpark_status = WispThread::_proxy_unpark_done;
     return;
+  }
+
+  if (jt->has_async_exception_condition()) {
+    assert(UseWisp2 && Wisp2ThreadStop, "pre-condition");
+    assert(jt->has_aync_thread_death_exception(), "must be wisp_thread_death_exception");
+    // JavaCalls will be skipped if current thread has a pending exception
+    // mannually clear all async exceptions before calling into java
+    jt->clear_aync_thread_death_exception();
   }
 
   wisp_thread->_unpark_status = WispThread::_wisp_unpark_begin;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1652,6 +1652,21 @@ JavaThread* JavaThread::active() {
   }
 }
 
+bool JavaThread::has_aync_thread_death_exception() {
+  assert(EnableCoroutine && Wisp2ThreadStop, "pre-condition");
+  return _pending_async_exception == Universe::wisp_thread_death_exception();
+}
+
+void JavaThread::clear_aync_thread_death_exception() {
+  assert(UseWisp2 && Wisp2ThreadStop, "pre-condition");
+  if (_pending_async_exception != NULL
+      && _pending_async_exception == Universe::wisp_thread_death_exception()) {
+    _pending_async_exception = NULL;
+    set_async_exception_condition(_no_async_condition);
+    clear_suspend_flag(_has_async_exception);
+  }
+}
+
 bool JavaThread::is_lock_owned(address adr) const {
   if (Thread::is_lock_owned(adr)) return true;
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1643,6 +1643,9 @@ class JavaThread: public Thread {
   bool has_attached_via_jni() const { return is_attaching_via_jni() || _jni_attach_state == _attached_via_jni; }
   inline void set_done_attaching_via_jni();
 
+  bool has_aync_thread_death_exception();
+  void clear_aync_thread_death_exception();
+
   // Stack dump assistance:
   // Track the class we want to initialize but for which we have to wait
   // on its init_lock() because it is already being initialized.

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
@@ -1,5 +1,6 @@
 package com.alibaba.wisp.engine;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -28,9 +29,14 @@ class ThreadAsWisp {
      * @return if condition is satisfied and thread is started as wisp
      */
     static boolean tryStart(Thread thread, Runnable target) {
-        if (!WispConfiguration.ALL_THREAD_AS_WISP
-                || WispEngine.isEngineThread(thread)
-                || matchBlackList(thread, target)) {
+        if (WispEngine.isEngineThread(thread)) {
+            return false;
+        }
+        if (WispConfiguration.ALL_THREAD_AS_WISP) {
+            if (matchList(thread, target, WispConfiguration.getThreadAsWispBlacklist())) {
+                return false;
+            }
+        } else if (!matchList(thread, target, WispConfiguration.getThreadAsWispWhitelist())) {
             return false;
         }
 
@@ -75,8 +81,8 @@ class ThreadAsWisp {
         }
     }
 
-    private static boolean matchBlackList(Thread thread, Runnable target) {
-        return Stream.concat(Stream.of(JAVA_LANG_PKG), WispConfiguration.getThreadAsWispBlacklist().stream())
+    private static boolean matchList(Thread thread, Runnable target, List<String> list) {
+        return Stream.concat(Stream.of(JAVA_LANG_PKG), list.stream())
                 .anyMatch(s -> {
                     Class<?> clazz = (target == null ? thread : target).getClass();
                     // Java code could start a thread by passing a `target` Runnable argument

--- a/src/java.base/share/classes/com/alibaba/wisp/engine/WispConfiguration.java
+++ b/src/java.base/share/classes/com/alibaba/wisp/engine/WispConfiguration.java
@@ -58,6 +58,7 @@ class WispConfiguration {
     static final int WISP_CONTROL_GROUP_CFS_PERIOD;
 
     private static List<String> THREAD_AS_WISP_BLACKLIST;
+    private static List<String> THREAD_AS_WISP_WHITELIST;
 
     static {
         Properties p = java.security.AccessController.doPrivileged(
@@ -134,10 +135,6 @@ class WispConfiguration {
                 ENABLE_THREAD_AS_WISP, "-Dcom.alibaba.wisp.enableThreadAsWisp=true");
         checkDependency(CARRIER_AS_POLLER, "-Dcom.alibaba.wisp.useCarrierAsPoller=true",
                 ALL_THREAD_AS_WISP, "-Dcom.alibaba.wisp.allThreadAsWisp=true");
-        if (ENABLE_THREAD_AS_WISP && !ALL_THREAD_AS_WISP) {
-            throw new IllegalArgumentException("shift thread model by stack configuration is no longer supported," +
-                    " use -XX:+UseWisp2 instead");
-        }
     }
 
     private static void checkDependency(boolean cond, String condStr, boolean preRequire, String preRequireStr) {
@@ -207,7 +204,7 @@ class WispConfiguration {
             }
         }
         THREAD_AS_WISP_BLACKLIST = parseListParameter(p, confProp, "com.alibaba.wisp.threadAsWisp.black");
-
+        THREAD_AS_WISP_WHITELIST = parseListParameter(p, confProp, "com.alibaba.wisp.threadAsWisp.white");
     }
 
     private static final int UNLOADED = 0, LOADING = 1, LOADED = 2;
@@ -231,5 +228,11 @@ class WispConfiguration {
         ensureBizConfigLoaded();
         assert THREAD_AS_WISP_BLACKLIST != null;
         return THREAD_AS_WISP_BLACKLIST;
+    }
+
+    static List<String> getThreadAsWispWhitelist() {
+        ensureBizConfigLoaded();
+        assert THREAD_AS_WISP_WHITELIST != null;
+        return THREAD_AS_WISP_WHITELIST;
     }
 }

--- a/test/jdk/com/alibaba/rcm/TestDeadLoopKillObjectMonitor.java
+++ b/test/jdk/com/alibaba/rcm/TestDeadLoopKillObjectMonitor.java
@@ -1,0 +1,74 @@
+/*
+ * @test
+ * @library /test/lib
+ * @build TestDeadLoopKillObjectMonitor RcmUtils
+ * @summary test RCM TestKillThreads
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @modules java.base/com.alibaba.rcm.internal:+open
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:+Wisp2ThreadStop -XX:ActiveProcessorCount=1 TestDeadLoopKillObjectMonitor
+ */
+
+import com.alibaba.rcm.Constraint;
+import com.alibaba.rcm.ResourceContainer;
+import com.alibaba.rcm.ResourceType;
+import com.alibaba.rcm.internal.RCMUnsafe;
+import com.alibaba.wisp.engine.WispResourceContainerFactory;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+public class TestDeadLoopKillObjectMonitor {
+
+    private static Object obj = new Object();
+
+    public static void main(String[] args) throws Exception {
+        ResourceContainer container = RcmUtils.createContainer(Collections.singletonList(
+                ResourceType.CPU_PERCENT.newConstraint(100)));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread t1 = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (obj) {
+                    try {
+                        Thread.sleep(1000);
+                        Thread t2 =  new Thread(new Runnable() {
+                            @Override
+                            public void run() {
+                                latch.countDown();
+                            }
+                        });
+                        t2.setDaemon(true);
+                        t2.start();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        });
+        t1.setDaemon(true);
+        t1.start();
+
+        Thread.sleep(100);
+        container.run(() -> {
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (true)
+                synchronized (obj) {
+                    System.out.println("rr");
+                }
+            }
+        });
+        t.start();
+        });
+
+        Thread.sleep(100);
+        RCMUnsafe.killThreads(container);
+    }
+
+}

--- a/test/jdk/com/alibaba/wisp2/TestThreadAsWispWhiteList.java
+++ b/test/jdk/com/alibaba/wisp2/TestThreadAsWispWhiteList.java
@@ -1,0 +1,30 @@
+/*
+ * @test
+ * @library /test/lib
+ * @summary test thread as wisp white list
+ * @modules java.base/jdk.internal.access
+ * @modules java.base/com.alibaba.wisp.engine:+open
+ * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=false -Dcom.alibaba.wisp.threadAsWisp.white=name:wisp-* TestThreadAsWispWhiteList
+ */
+
+import jdk.internal.access.SharedSecrets;
+
+import java.util.concurrent.FutureTask;
+
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class TestThreadAsWispWhiteList {
+    public static void main(String[] args) throws Exception {
+        FutureTask<Boolean> future = new FutureTask<>(TestThreadAsWispWhiteList::isRealThread);
+        new Thread(future, "wisp-1").start();
+        assertFalse(future.get());
+        future = new FutureTask<>(TestThreadAsWispWhiteList::isRealThread);
+        new Thread(future, "thread-1").start();
+        assertTrue(future.get());
+    }
+
+    private static boolean isRealThread() {
+        return SharedSecrets.getJavaLangAccess().currentThread0() == Thread.currentThread();
+    }
+}


### PR DESCRIPTION
This patch contains 2 dragonwell11 patches.

Original patch url:
https://github.com/dragonwell-project/dragonwell11/commit/5f8df2d26aeb57212f23dc155aff75973bb1a7c4
https://github.com/dragonwell-project/dragonwell11/commit/27561588ec2797db945525d165945334f0e294e2

Test Plan: all wisp tests

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/146

---

[Wisp] Thread as Wisp whitelist
Summary: Provides a way to run thread as wisp using
configuration

Test Plan: TestThreadAsWispWhiteList

---

[Wisp] Fix dead loop when killing threads waiting for objectmonitor
Summary: Threads waiting for objectmonitor will skip calling
WispTask::park when async exception is pending, so mannualy
clear exception before WispThread::park

Test Plan: jtreg test/jdk/com/alibaba/rcm/TestDeadLoopKillObjectMonitor.java

---