### PR TITLE
[Wisp] Blocking io support for SocketChannel and Pipe and fix bugs. 

### DIFF
--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -27,12 +27,14 @@ import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.WispEngineAccess;
 import jdk.internal.ref.CleanerFactory;
+import sun.nio.ch.Net;
 
 import java.dyn.Coroutine;
 import java.dyn.CoroutineExitException;
 import java.dyn.CoroutineSupport;
 import java.io.IOException;
 import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -377,6 +379,37 @@ public class WispEngine extends AbstractExecutorService {
                 } else {
                     return task.status == WispTask.Status.CACHED ? Thread.State.TERMINATED : Thread.State.RUNNABLE;
                 }
+            }
+
+            @Override
+            public int poll(SelectableChannel channel, int interestOps, long millsTimeOut) throws IOException {
+                assert interestOps == Net.POLLIN || interestOps == Net.POLLCONN || interestOps == Net.POLLOUT;
+                WispTask task = WispCarrier.current().getCurrentTask();
+                if (millsTimeOut > 0) {
+                    task.carrier.addTimer(System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(millsTimeOut),
+                            TimeOut.Action.JDK_UNPARK);
+                }
+                try {
+                    task.carrier.registerEvent(channel, translateToSelectionKey(interestOps));
+                    park(-1);
+                    return millsTimeOut > 0 && task.timeOut.expired() ? 0 : 1;
+                } finally {
+                    if (millsTimeOut > 0) {
+                        task.carrier.cancelTimer();
+                    }
+                    unregisterEvent();
+                }
+            }
+
+            private int translateToSelectionKey(int event) {
+                if (Net.POLLIN == event) {
+                    return SelectionKey.OP_READ;
+                } else if (Net.POLLCONN == event) {
+                    return SelectionKey.OP_CONNECT;
+                } else if (Net.POLLOUT == event) {
+                    return SelectionKey.OP_WRITE;
+                }
+                return 0;
             }
         });
     }

--- a/src/java.base/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -178,7 +178,12 @@ public class WispEngine {
             public Thread.State getState(Thread thread) {
                 return null;
             }
-            });
+
+            @Override
+            public int poll(SelectableChannel channel, int interestOps, long timeout) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+        });
     }
 
 }

--- a/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AbstractSelectableChannel.java
@@ -25,15 +25,12 @@
 
 package java.nio.channels.spi;
 
+import com.alibaba.wisp.engine.WispEngine;
+import sun.nio.ch.IOUtil;
+
+import java.io.FileDescriptor;
 import java.io.IOException;
-import java.nio.channels.CancelledKeyException;
-import java.nio.channels.ClosedChannelException;
-import java.nio.channels.ClosedSelectorException;
-import java.nio.channels.IllegalBlockingModeException;
-import java.nio.channels.IllegalSelectorException;
-import java.nio.channels.SelectableChannel;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
+import java.nio.channels.*;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
@@ -292,6 +289,17 @@ public abstract class AbstractSelectableChannel
      */
     protected abstract void implCloseSelectableChannel() throws IOException;
 
+    /**
+     * Configure fd to non-blocking mode.
+     *
+     * @param fd fd to configure
+     * @throws IOException underlying IO error
+     */
+    protected void configureAsNonBlockingForWisp(FileDescriptor fd) throws IOException {
+        if (WispEngine.transparentWispSwitch()) {
+            IOUtil.configureBlocking(fd, false);
+        }
+    }
 
     // -- Blocking --
 
@@ -321,7 +329,10 @@ public abstract class AbstractSelectableChannel
             if (block != blocking) {
                 if (block && haveValidKeys())
                     throw new IllegalBlockingModeException();
-                implConfigureBlocking(block);
+                if (!(WispEngine.transparentWispSwitch()
+                        && (this instanceof ServerSocketChannel || this instanceof SocketChannel))) {
+                    implConfigureBlocking(block);
+                }
                 nonBlocking = !block;
             }
         }

--- a/src/java.base/share/classes/jdk/internal/access/WispEngineAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/WispEngineAccess.java
@@ -62,4 +62,13 @@ public interface WispEngineAccess {
     WispTask getWispTaskById(long id);
 
     Thread.State getState(Thread thread);
+
+    /**
+     * @param channel     Blocking SocketChannel waiting for interestOps
+     * @param interestOps Net.* enum constant interests
+     * @param timeout     timeout in milliseconds
+     * @return active event count
+     * @throws IOException
+     */
+    int poll(SelectableChannel channel, int interestOps, long timeout) throws IOException;
 }

--- a/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
@@ -27,6 +27,7 @@ package sun.nio.ch;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.ClosedChannelException;
@@ -81,6 +82,11 @@ class SinkChannelImpl
         super(sp);
         this.fd = fd;
         this.fdVal = IOUtil.fdVal(fd);
+        try {
+            configureAsNonBlockingForWisp(fd);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unexpected error at configureAsNonBlockingForWisp", e);
+        }
     }
 
     /**

--- a/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
@@ -27,6 +27,7 @@ package sun.nio.ch;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.ClosedChannelException;
@@ -81,6 +82,11 @@ class SourceChannelImpl
         super(sp);
         this.fd = fd;
         this.fdVal = IOUtil.fdVal(fd);
+        try {
+            configureAsNonBlockingForWisp(fd);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unexpected error at configureAsNonBlockingForWisp", e);
+        }
     }
 
     /**

--- a/src/java.base/windows/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/windows/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -177,6 +177,11 @@ public class WispEngine {
             public Thread.State getState(Thread thread) {
                 return null;
             }
+
+            @Override
+            public int poll(SelectableChannel channel, int interestOps, long timeout) throws IOException {
+                throw new UnsupportedOperationException();
+            }
         });
     }
 

--- a/src/java.management/share/classes/sun/management/ThreadImpl.java
+++ b/src/java.management/share/classes/sun/management/ThreadImpl.java
@@ -26,6 +26,7 @@
 package sun.management;
 
 import com.alibaba.wisp.engine.WispEngine;
+import com.alibaba.wisp.engine.WispTask;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.WispEngineAccess;
 
@@ -206,7 +207,11 @@ public class ThreadImpl implements ThreadMXBean {
         if (WispEngine.enableThreadAsWisp()) {
             for (int i = 0; i < infos.length; i++) {
                 if (infos[i] == null) {
-                    infos[i] = ThreadInfo.from(new WispThreadCompositeData(WEA.getWispTaskById(ids[i])));
+                    WispTask task = WEA.getWispTaskById(ids[i]);
+                    if (task == null) {
+                        continue;
+                    }
+                    infos[i] = ThreadInfo.from(new WispThreadCompositeData(task));
                 }
             }
         }

--- a/src/java.management/share/classes/sun/management/WispThreadCompositeData.java
+++ b/src/java.management/share/classes/sun/management/WispThreadCompositeData.java
@@ -16,17 +16,18 @@ public class WispThreadCompositeData extends LazyCompositeData {
     private final WispTask task;
 
     public WispThreadCompositeData(WispTask wispTask) {
+        assert wispTask != null : "handled null cases already";
         task = wispTask;
     }
 
     @Override
     protected CompositeData getCompositeData() {
         Map<String, Object> items = new HashMap<>();
-        Thread t = task != null ? task.getThreadWrapper() : null;
+        Thread t = task.getThreadWrapper();
         Object parkBlocker = t != null ? LockSupport.getBlocker(t) : null;
         items.put(THREAD_ID,        t != null ? t.getId() : 0L);
         items.put(THREAD_NAME,      t != null ? t.getName() : "");
-        items.put(THREAD_STATE,     t != null ? t.getState().name() : "");
+        items.put(THREAD_STATE,     t != null ? t.getState().name() : Thread.State.TERMINATED.toString());
         items.put(LOCK_NAME,        parkBlocker == null ? "" : parkBlocker.toString());
         items.put(BLOCKED_TIME,     0L);
         items.put(BLOCKED_COUNT,    0L);

--- a/src/java.management/share/classes/sun/management/WispThreadCompositeData.java
+++ b/src/java.management/share/classes/sun/management/WispThreadCompositeData.java
@@ -23,7 +23,7 @@ public class WispThreadCompositeData extends LazyCompositeData {
     protected CompositeData getCompositeData() {
         Map<String, Object> items = new HashMap<>();
         Thread t = task != null ? task.getThreadWrapper() : null;
-        Object parkBlocker = LockSupport.getBlocker(t);
+        Object parkBlocker = t != null ? LockSupport.getBlocker(t) : null;
         items.put(THREAD_ID,        t != null ? t.getId() : 0L);
         items.put(THREAD_NAME,      t != null ? t.getName() : "");
         items.put(THREAD_STATE,     t != null ? t.getState().name() : "");
@@ -40,7 +40,7 @@ public class WispThreadCompositeData extends LazyCompositeData {
         items.put(LOCKED_MONITORS,  new CompositeData[0]);
         items.put(LOCKED_SYNCS,     new CompositeData[0]);
         items.put(LOCK_INFO,        null);
-        items.put(DAEMON,           t == null && t.isDaemon());
+        items.put(DAEMON,           t != null && t.isDaemon());
         items.put(PRIORITY,         t != null ? t.getPriority() : 0);
 
         try {

--- a/test/jdk/com/alibaba/wisp/io/TestBlockingAccept2.java
+++ b/test/jdk/com/alibaba/wisp/io/TestBlockingAccept2.java
@@ -25,18 +25,18 @@ public class TestBlockingAccept2 {
                 latch.await(1, TimeUnit.SECONDS);
                 Thread.sleep(200);
                 Socket s = new Socket();
-                s.connect(new InetSocketAddress(12388));
+                s.connect(new InetSocketAddress(12389));
                 latch2.await(1, TimeUnit.SECONDS);
                 s.close();
                 Thread.sleep(200);
                 s = new Socket();
-                s.connect(new InetSocketAddress(12388));
+                s.connect(new InetSocketAddress(12389));
             } catch (Exception e) {
             }
         });
         t.start();
         ServerSocketChannel ssc = ServerSocketChannel.open();
-        ssc.bind(new InetSocketAddress(12388));
+        ssc.bind(new InetSocketAddress(12389));
         latch.countDown();
         ssc.accept();
         latch2.countDown();

--- a/test/jdk/com/alibaba/wisp/io/TestBlockingNIO.java
+++ b/test/jdk/com/alibaba/wisp/io/TestBlockingNIO.java
@@ -1,0 +1,182 @@
+/*
+ * @test
+ * @library /test/lib
+ * @summary test blocking nio
+ * @requires os.family == "linux"
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestBlockingNIO
+ */
+
+import com.alibaba.wisp.engine.WispEngine;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Pipe;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Asserts.*;
+
+
+public class TestBlockingNIO {
+    static CountDownLatch latch = new CountDownLatch(1);
+
+    public static void main(String[] args) throws Exception {
+        BlockingSemantic();
+        Accept2Test();
+        PipeTest();
+        AdaptorTest();
+
+        boolean te = false;
+        try {
+            TimeOutTest();
+        } catch (SocketTimeoutException e) {
+            te = true;
+        }
+
+        assertTrue(te);
+        assertTrue(latch.getCount() == 1);
+    }
+
+    static void BlockingSemantic() throws Exception {
+
+        WispEngine.dispatch(() -> {
+            try {
+                ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+                serverSocketChannel.bind(new InetSocketAddress(12312));
+                serverSocketChannel.configureBlocking(true);
+                serverSocketChannel.accept();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    static void Accept2Test() throws Exception {
+        CountDownLatch serverReady = new CountDownLatch(1);
+        CountDownLatch reading = new CountDownLatch(1);
+
+        Thread t = new Thread(() -> {
+            try {
+                serverReady.await(1, TimeUnit.SECONDS);
+                SocketChannel s = SocketChannel.open();
+                s.connect(new InetSocketAddress(12388));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t.start();
+        Thread t2 = new Thread(() -> {
+            try {
+                ServerSocketChannel ssc = ServerSocketChannel.open();
+                ssc.configureBlocking(true);
+                ssc.bind(new InetSocketAddress(12388));
+                serverReady.countDown();
+                SocketChannel channel = ssc.accept();
+                reading.countDown();
+                channel.read(ByteBuffer.allocate(203));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t2.start();
+
+        reading.await();
+        CountDownLatch suc = new CountDownLatch(1);
+        new Thread(() -> {
+            try {
+                Thread.sleep(2_000L);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            suc.countDown();
+        }).start();
+
+        suc.await();
+    }
+
+
+    static void PipeTest() throws Exception {
+        Pipe pipe = Pipe.open();
+        Pipe.SinkChannel sinkChannel = pipe.sink();
+        Pipe.SourceChannel sourceChannel = pipe.source();
+
+        CountDownLatch blocking = new CountDownLatch(1);
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    blocking.countDown();
+                    sourceChannel.read(ByteBuffer.allocate(44));
+                    // should block
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }).start();
+
+        blocking.await();
+
+        CountDownLatch suc = new CountDownLatch(1);
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                suc.countDown();
+            }
+        }).start();
+
+        suc.await();// if carrier is blocking in nio this may hang here
+    }
+
+
+    static void AdaptorTest() throws Exception {
+
+        CountDownLatch serverStarted = new CountDownLatch(1);
+        Thread t2 = new Thread(() -> {
+            try {
+                ServerSocketChannel ssc = ServerSocketChannel.open();
+                ssc.configureBlocking(true);
+                ssc.bind(new InetSocketAddress(12388));
+                ssc.accept();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t2.start();
+
+
+        Thread t1 = new Thread(() -> {
+            try {
+                SocketChannel channel = SocketChannel.open();
+                channel.configureBlocking(true);
+                channel.socket().setSoTimeout(200000);
+                channel.socket().connect(new InetSocketAddress(12388));
+                int v = channel.socket().getInputStream().read(new byte[2031]);
+                System.out.println(v);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t1.start();
+
+
+        CountDownLatch latch = new CountDownLatch(1);
+        WispEngine.dispatch(latch::countDown);
+
+        latch.await();
+    }
+
+    static void TimeOutTest() throws Exception {
+        ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        serverSocketChannel.configureBlocking(true);
+        serverSocketChannel.socket().setSoTimeout(200);
+        serverSocketChannel.socket().bind(new InetSocketAddress(2333));
+        serverSocketChannel.socket().accept();
+    }
+}


### PR DESCRIPTION
This patch contains 4 dragonwell11 patches.

Original patch url:
https://github.com/dragonwell-project/dragonwell11/commit/6c3b97025ef5f255ccabd999766166c77483bc56
https://github.com/dragonwell-project/dragonwell11/commit/4d7dbb84114c7914a0ccbc9d125ab2b93ee224a8
https://github.com/dragonwell-project/dragonwell11/commit/d2bba637430a88105b77f10248d7a0853e16ac0e
https://github.com/dragonwell-project/dragonwell11/commit/00310813b9e48ee7d57f1dd71d8eef66858b454b

Test Plan: all wisp tests

Reviewed-by: yulei

---

[Wisp] Blocking io support for SocketChannel and Pipe
Summary: Hook blocking entry at pipeChannel and SocketChannel,
  current WispTask would block itself to wait for next scheduling.

Test Plan: jtreg TestBlockIngIO.

---

[Misc] fix port conflict between TestBlockingAccept2.java and TestBlockingAccept2.java

Summary: fix port conflict between com/alibaba/wisp/io/TestBlockingAccept2.java and com/alibaba/wisp/io/TestBlockingNIO.java

Test Plan: CI pipeline

---

[Wisp] WispThreadCompositeData.getCompositeData() should handle null WispTask

Summary: WispThreadCompositeData.getCompositeData() uses LockSupport.getBlocker(), which would throw NPE to break its process.

Test Plan: com/alibaba/wisp/thread/TestThreadInfo.java

---

[Wisp] WispThreadCompositeData.getCompositeData() should use legal Thread State String

Summary: sun.management.ThreadInfoCompositeData.threadState() will use valueOf() to read Thread.State String. We should specify a TERMINATED String for it. Also, a cleanup.

Test Plan: com/alibaba/wisp/thread/TestThreadInfo.java

---