### PR TITLE
[Wisp] Separate IO poller and fix test/jdk/java/dyn tests.

### DIFF
--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
@@ -67,6 +67,7 @@ class WispConfiguration {
     static final int WISP_SHUTDOWN_SLEEP_TIME;
     static final WispScheduler.SchedulingPolicy SCHEDULING_POLICY;
     static final boolean USE_DIRECT_SELECTOR_WAKEUP;
+    static final boolean SEPARATE_IO_POLLER;
     static final boolean CARRIER_AS_POLLER;
     static final boolean MONOLITHIC_POLL;
     static final boolean CARRIER_GROW;
@@ -125,7 +126,9 @@ class WispConfiguration {
             WISP_PROFILE_LOG_PATH = "";
         }
 
-        CARRIER_AS_POLLER = parseBooleanParameter(p, "com.alibaba.wisp.useCarrierAsPoller", ALL_THREAD_AS_WISP);
+        SEPARATE_IO_POLLER = parseBooleanParameter(p, "com.alibaba.wisp.separateIOPoller", false);
+        CARRIER_AS_POLLER = parseBooleanParameter(p, "com.alibaba.wisp.useCarrierAsPoller",
+                ALL_THREAD_AS_WISP && (!SEPARATE_IO_POLLER || WORKER_COUNT / POLLER_SHARDING_SIZE > 1));
         MONOLITHIC_POLL = parseBooleanParameter(p, "com.alibaba.wisp.monolithicPoll", true);
         WISP_HIGH_PRECISION_TIMER = parseBooleanParameter(p, "com.alibaba.wisp.highPrecisionTimer", false);
         WISP_USE_STEAL_LOCK = parseBooleanParameter(p, "com.alibaba.wisp.useStealLock", true);

--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEventPump.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEventPump.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 
-
 class WispEventPump {
     private static final int LOW_FD_BOUND = 1024 * 10;
     private static final int MAX_EVENTS_TO_POLL = 512;
@@ -79,6 +78,9 @@ class WispEventPump {
         Pool() {
             int n = Math.max(1, WispConfiguration.WORKER_COUNT / WispConfiguration.POLLER_SHARDING_SIZE);
             n = (n & (n - 1)) == 0 ? n : Integer.highestOneBit(n) * 2; // next power of 2
+            if (WispConfiguration.SEPARATE_IO_POLLER) {
+                n = Math.max(2, n);
+            }
             mask = n - 1;
             pumps = new WispEventPump[n];
             for (int i = 0; i < pumps.length; i++) {
@@ -107,16 +109,21 @@ class WispEventPump {
             return x * (int) 2654435761L;
         }
 
+        private WispEventPump pumpFromFd(int fd, boolean isRead) {
+            int offset = WispConfiguration.SEPARATE_IO_POLLER && !isRead ? 0 : 1;
+            return pumps[(hash(fd) + offset) & mask];
+        }
+
         void registerEvent(WispTask task, SelectableChannel ch, int event) throws IOException {
             if (ch != null && ch.isOpen()) {
                 int fd = ((SelChImpl) ch).getFDVal();
-                pumps[hash(fd) & mask].registerEvent(task, fd, event);
+                pumpFromFd(fd, isNativeReadEvent(toNativeEvent(event))).registerEvent(task, fd, event);
             }
         }
 
         int eventWaitForWisp(int epfd, long pollArray, int arraySize, long timeout, AtomicReference<Object> status,
                              final Object INTERRUPTED) throws IOException {
-            return pumps[hash(epfd) & mask].eventWaitForWisp(epfd, pollArray, arraySize, timeout, status, INTERRUPTED);
+            return pumpFromFd(epfd, true).eventWaitForWisp(epfd, pollArray, arraySize, timeout, status, INTERRUPTED);
         }
 
         void interruptEpoll(AtomicReference<Object> status, Object INTERRUPTED, int interruptFd) {
@@ -143,18 +150,18 @@ class WispEventPump {
     /**
      * whether event is a reading event or an accepting event
      */
-    private boolean isReadEvent(int events) throws IllegalArgumentException {
+    private static boolean isNativeReadEvent(int events) throws IllegalArgumentException {
         int event = (events & (Net.POLLCONN | Net.POLLIN | Net.POLLOUT));
         assert Integer.bitCount(event) == 1;
         return (events & Net.POLLIN) != 0;
     }
 
     private WispTask[] getFd2TaskLow(int events) {
-        return isReadEvent(events) ? fd2ReadTaskLow : fd2WriteTaskLow;
+        return isNativeReadEvent(events) ? fd2ReadTaskLow : fd2WriteTaskLow;
     }
 
     private ConcurrentHashMap<Integer, WispTask> getFd2TaskHigh(int events) {
-        return isReadEvent(events) ? fd2ReadTaskHigh : fd2WriteTaskHigh;
+        return isNativeReadEvent(events) ? fd2ReadTaskHigh : fd2WriteTaskHigh;
     }
 
     private boolean sanityCheck(int fd, WispTask newTask, int events) {
@@ -190,12 +197,17 @@ class WispEventPump {
         return task;
     }
 
-    private void registerEvent(WispTask task, int fd, int event) throws IOException {
-        int ev = 0;
+    private static int toNativeEvent(int events) {
         // Translates an interest operation set into a native poll event set
-        if ((event & (SelectionKey.OP_READ | SelectionKey.OP_ACCEPT)) != 0) ev |= Net.POLLIN;
-        if ((event & SelectionKey.OP_WRITE) != 0) ev |= Net.POLLOUT;
-        if ((event & SelectionKey.OP_CONNECT) != 0) ev |= Net.POLLCONN;
+        int ev = 0;
+        if ((events & (SelectionKey.OP_READ | SelectionKey.OP_ACCEPT)) != 0) ev |= Net.POLLIN;
+        if ((events & SelectionKey.OP_WRITE) != 0) ev |= Net.POLLOUT;
+        if ((events & SelectionKey.OP_CONNECT) != 0) ev |= Net.POLLCONN;
+        return ev;
+    }
+
+    private void registerEvent(WispTask task, int fd, int event) throws IOException {
+        int ev = toNativeEvent(event);
         // When the socket is closed, the poll event will be triggered
         ev |= Net.POLLHUP;
         // specify the EPOLLONESHOT flag, to tell epoll to disable the associated

--- a/test/jdk/com/alibaba/wisp/io/WispFileIOTest.java
+++ b/test/jdk/com/alibaba/wisp/io/WispFileIOTest.java
@@ -4,7 +4,7 @@
  * @summary test reuse WispUdpSocket buffer
  * @modules java.base/jdk.internal.access
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.enableAsyncFileIO=true WispFileIOTest
+ * @run main/othervm/timeout=2000 -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.enableAsyncFileIO=true WispFileIOTest
  */
 
 import jdk.internal.access.SharedSecrets;

--- a/test/jdk/com/alibaba/wisp/thread/TestThreadInfo.java
+++ b/test/jdk/com/alibaba/wisp/thread/TestThreadInfo.java
@@ -14,7 +14,7 @@ import java.lang.management.ThreadMXBean;
 import java.util.concurrent.locks.LockSupport;
 
 import static jdk.test.lib.Asserts.assertEQ;
-import static jdk.test.lib.Asserts.assertNotNull;
+import static jdk.test.lib.Asserts.assertTrue;
 
 
 public class TestThreadInfo {
@@ -30,8 +30,10 @@ public class TestThreadInfo {
         ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
         ThreadInfo[] infos = tmx.getThreadInfo(ids);
         for (int i = 0; i < infos.length; i++) {
-            assertNotNull(infos[i]);
-            assertEQ(infos[i].getThreadState(), Thread.State.WAITING);
+            if (infos[i] == null) {
+                continue;
+            }
+            assertTrue(infos[i].getThreadState() == Thread.State.WAITING || infos[i].getThreadState() == Thread.State.TERMINATED);
             assertEQ(infos[i].getLockName(), blocker.toString());
             assertEQ(infos[i].getThreadId(), ids[i]);
             assertEQ(infos[i].getThreadName(), "t" + i);

--- a/test/jdk/com/alibaba/wisp2/bug/TestIssue311.java
+++ b/test/jdk/com/alibaba/wisp2/bug/TestIssue311.java
@@ -1,0 +1,52 @@
+/*
+ * @test
+ * @library /test/lib
+ * @summary Test different coroutines waiting on the same socket's read and write events.
+ * @requires os.family == "linux"
+ * @run main/timeout=10/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.separateIOPoller=true TestIssue311
+ */
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class TestIssue311 {
+    public static void main(String[] args) throws Exception {
+        Socket client = startEchoServer();
+        new Thread(() -> {
+            try {
+                byte[] buf = new byte[1024];
+                while (true) { // discard all data
+                    client.getInputStream().read(buf, 0, buf.length);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+
+        byte[] buf = new byte[1024 * 1024];
+        for (int i = 0; i < 100; i++) {
+            client.getOutputStream().write(buf, 0, buf.length);
+        }
+    }
+
+
+    private static Socket startEchoServer() throws Exception {
+        ServerSocket serverSocket = new ServerSocket(0);
+        Socket socket = new Socket("localhost", serverSocket.getLocalPort());
+        new Thread(() -> {
+            try {
+                Socket clientSocket = serverSocket.accept();
+                byte[] buf = new byte[1024];
+                int len;
+                while ((len = clientSocket.getInputStream().read(buf)) > 0) {
+                    clientSocket.getOutputStream().write(buf, 0, len);
+                }
+                clientSocket.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+        return socket;
+    }
+}


### PR DESCRIPTION
This patch contains 2 dragonwell11 patches.

Original patch url:
https://github.com/dragonwell-project/dragonwell11/commit/c7546a7b56792a45cc7c2d52afd8fe548dce6665
https://github.com/dragonwell-project/dragonwell11/commit/2f378375ca7ad0f74df09aa021ab8fd6ab297ddf

Test Plan: all wisp tests

Reviewed-by: yulei

---

[Wisp] Separate IO poller
Summary: Supports different coroutines waiting on the same socket's
read and write events. Solve a wisp bug triggered by okhttp.

Test Plan: TestIssue311

---

[Wisp] Fix test/jdk/java/dyn tests
Summary: Fix tests

Test Plan: test/jdk/java/dyn

---
