### PR TITLE
[Wisp] Fix bugs and unstable tests.

### DIFF
--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -214,8 +214,8 @@ class VirtualSpace {
  public:
   // Initialization
   VirtualSpace();
-  bool initialize_with_granularity(ReservedSpace rs, size_t committed_byte_size, size_t max_commit_ganularity);
-  bool initialize(ReservedSpace rs, size_t committed_byte_size);
+  bool initialize_with_granularity(ReservedSpace rs, size_t committed_byte_size, size_t max_commit_ganularity, bool force_ignore_pretouch = false);
+  bool initialize(ReservedSpace rs, size_t committed_byte_size, bool force_ignore_pretouch = false);
 
   // Destruction
   ~VirtualSpace();
@@ -233,7 +233,7 @@ class VirtualSpace {
 
   // Operations
   // returns true on success, false otherwise
-  bool expand_by(size_t bytes, bool pre_touch = false);
+  bool expand_by(size_t bytes, bool pre_touch = false, bool force_ignore_pretouch = false);
   void shrink_by(size_t bytes);
   void release();
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -412,7 +412,7 @@ JRT_END
 JRT_ENTRY_NO_ASYNC(void, OptoRuntime::complete_wisp_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* current))
   assert(EnableCoroutine, "Coroutine is disabled");
   Handle h_obj(current, obj);
-  SharedRuntime::monitor_exit_helper(h_obj, lock, current);
+  SharedRuntime::monitor_exit_helper<Handle>(h_obj, lock, current);
 JRT_END
 
 JRT_BLOCK_ENTRY(void, OptoRuntime::monitor_notify_C(oopDesc* obj, JavaThread* current))

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2170,7 +2170,7 @@ JRT_END
 JRT_LEAF(void, SharedRuntime::complete_wisp_proxy_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* current))
   WispThread* wisp_thread = WispThread::current(current);
   wisp_thread->set_proxy_unpark_flag();
-  SharedRuntime::monitor_exit_helper(obj, lock, current);
+  SharedRuntime::monitor_exit_helper<oopDesc*>(obj, lock, current);
   wisp_thread->clear_proxy_unpark_flag();
 JRT_END
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1043,17 +1043,13 @@ class JavaThread: public Thread {
   int _frames_to_pop_failed_realloc;
 
   // coroutine support
-  volatile long     _coroutine_support_lock;
+  volatile int      _coroutine_list_lock;
   Coroutine*        _coroutine_list;
-
   Coroutine*        _current_coroutine;
   bool              _wisp_preempted;
 
  public:
-  volatile long* const coroutine_support_lock()  { return &_coroutine_support_lock; }
-  // coroutine_support_lock_owner is only used in if-else.
-  // So there is no need for load_acquire semantic.
-  volatile long coroutine_support_lock_owner()   { return _coroutine_support_lock; }
+  volatile int* const coroutine_list_lock()      { return &_coroutine_list_lock; }
   Coroutine*& coroutine_list()                   { return _coroutine_list; }
   Coroutine* current_coroutine()                 { return _current_coroutine; }
   void set_current_coroutine(Coroutine *coro)    { _current_coroutine = coro; }

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -304,9 +304,9 @@ public class Thread implements Runnable {
     /**
      * initialize the coroutine support of the thread
      */
-    private void initializeCoroutineSupport(long nativeThreadId, long lockOwnerAddress) {
+    private void initializeCoroutineSupport() {
         if (coroutineSupport == null) {
-            coroutineSupport = new CoroutineSupport(this, nativeThreadId, lockOwnerAddress);
+            coroutineSupport = new CoroutineSupport(this);
         }
     }
 

--- a/test/jdk/com/alibaba/rcm/TestKillThreads.java
+++ b/test/jdk/com/alibaba/rcm/TestKillThreads.java
@@ -7,7 +7,7 @@
  * @modules java.base/com.alibaba.rcm.internal:+open
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:+Wisp2ThreadStop -XX:ActiveProcessorCount=4 TestKillThreads
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -Dcom.alibaba.wisp.threadAsWisp.black=name:Tester* -XX:+UseWisp2 -XX:+Wisp2ThreadStop -XX:ActiveProcessorCount=4 TestKillThreads
- * @run main/othervm -Xcomp -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:+Wisp2ThreadStop -XX:ActiveProcessorCount=4 TestKillThreads
+ * @run main/othervm/timeout=600 -Xcomp -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:+Wisp2ThreadStop -XX:ActiveProcessorCount=4 TestKillThreads
  * @run main/othervm -Xint -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:+Wisp2ThreadStop -XX:ActiveProcessorCount=4 TestKillThreads
  * @run main/othervm -client -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:+Wisp2ThreadStop -XX:ActiveProcessorCount=4 TestKillThreads
  */

--- a/test/jdk/com/alibaba/wisp/bug/TestThreadObjGC.java
+++ b/test/jdk/com/alibaba/wisp/bug/TestThreadObjGC.java
@@ -1,0 +1,57 @@
+
+/*
+ * @test
+ * @library /test/lib
+ * @summary Test fix of WispEngine block on Thread.class lock
+ * @modules java.base/java.lang:+open
+ * @requires os.family == "linux"
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestThreadObjGC
+ */
+
+import java.util.Arrays;
+import java.util.List;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestThreadObjGC {
+
+    private static ProcessBuilder processBuilder = new ProcessBuilder();
+
+    public static void main(String[] args) throws Exception {
+        new TestThread(() -> {
+            System.out.println("test");
+        }).start();
+        System.gc();
+        Thread.sleep(1000);
+        OutputAnalyzer output = jmap("-histo:live");
+        output.shouldHaveExitValue(0);
+        output.shouldNotContain("TestThreadObjGC$TestThread");
+    }
+
+    static class TestThread extends Thread {
+        public TestThread(Runnable task) {
+            super(task);
+        }
+    }
+
+    private static OutputAnalyzer jmap(String... toolArgs) throws Exception {
+        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jmap");
+        launcher.addVMArgs(Utils.getTestJavaOpts());
+        if (toolArgs != null) {
+            for (String toolArg : toolArgs) {
+                launcher.addToolArg(toolArg);
+            }
+        }
+        launcher.addToolArg(Long.toString(ProcessTools.getProcessId()));
+
+        processBuilder.command(launcher.getCommand());
+        System.out.println(Arrays.toString(processBuilder.command().toArray()));
+        OutputAnalyzer output = ProcessTools.executeProcess(processBuilder);
+        System.out.println(output.getOutput());
+
+        return output;
+    }
+}

--- a/test/jdk/com/alibaba/wisp/exclusive/lock/TestLock.java
+++ b/test/jdk/com/alibaba/wisp/exclusive/lock/TestLock.java
@@ -31,7 +31,7 @@ public class TestLock {
         WispEngine.dispatch(TestLock::p1);
         WispEngine.dispatch(TestLock::p2);
 
-        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
     private static void assertInterval(long start, int diff, int bias) {

--- a/test/jdk/com/alibaba/wisp/exclusive/thread/TestDaemon.java
+++ b/test/jdk/com/alibaba/wisp/exclusive/thread/TestDaemon.java
@@ -34,7 +34,7 @@ public class TestDaemon {
                 System.out.println("thread started..");
                 if (!daemon) {
                     try {
-                        Thread.sleep(2000);
+                        Thread.sleep(4000);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
@@ -50,7 +50,7 @@ public class TestDaemon {
         // we can not use jdk.testlibrary.ProcessTools here, because we need to analyse stdout of a unfinished process
         Process process = new ProcessBuilder(System.getProperty("java.home") + "/bin/java", "-XX:+UnlockExperimentalVMOptions",
                 "-XX:+UseWisp2", "-cp", System.getProperty("java.class.path"), TestDaemon.class.getName(), Boolean.toString(daemon)).start();
-        Thread.sleep(2000);
+        Thread.sleep(4000);
         byte[] buffer = new byte[1024];
         int n = process.getInputStream().read(buffer);
         String s = new String(buffer, 0, n);

--- a/test/jdk/java/net/httpclient/ConnectExceptionTest.java
+++ b/test/jdk/java/net/httpclient/ConnectExceptionTest.java
@@ -26,7 +26,7 @@
  * @summary Expect ConnectException for all non-security related connect errors
  * @bug 8204864
  * @run testng/othervm -Djdk.net.hosts.file=HostFileDoesNotExist ConnectExceptionTest
- * @run testng/othervm/java.security.policy=noPermissions.policy ConnectExceptionTest
+ * @run testng/othervm/java.security.policy=ConnectExceptionTest.policy ConnectExceptionTest
  */
 
 import java.io.IOException;


### PR DESCRIPTION
Summary:
1. Bypass PreTouch logical when creating coroutine stack.
2. Fix some wisp tests failed in slowdebug.
3. Fix ConnectExceptionTest.java test failed after merge upstream.
4. Fix build failed when make linux-x64.
5. Refine CoroutineListLocker to protect _coroutine_list in vm, and restore CoroutineSupportLock in java.
6. Fix threadObj not been correctly released from OopStorage.

Test Plan: CI pipeline

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/159