### PR TITLE
[Wisp] Fix wisp poller dead lock in PUSH scheduling policy.

### DIFF
--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEventPump.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEventPump.java
@@ -181,7 +181,11 @@ class WispEventPump {
         if (fd < LOW_FD_BOUND) {
             getFd2TaskLow(events)[fd] = task;
         } else {
+            WispCarrier carrier = WispCarrier.current();
+            final boolean isInCritical0 = carrier.isInCritical;
+            carrier.isInCritical = true;
             getFd2TaskHigh(events).put(fd, task);
+            carrier.isInCritical = isInCritical0;
         }
     }
 
@@ -192,7 +196,11 @@ class WispEventPump {
             task = fd2TaskLow[fd];
             fd2TaskLow[fd] = null;
         } else {
+            WispCarrier carrier = WispCarrier.current();
+            final boolean isInCritical0 = carrier.isInCritical;
+            carrier.isInCritical = true;
             task = getFd2TaskHigh(events).remove(fd);
+            carrier.isInCritical = isInCritical0;
         }
         return task;
     }


### PR DESCRIPTION
Summary:
Assume a coroutine that is waiting a synchronize monitor was scheduled to a carrier thread, and the carrier thread is doing as a poller. If the poller is trying to get this synchronize monitor at this moment, and then the poller will park because can not acquire the monitor. This case will cause a deadlock.

Test Plan: test/jdk/com/alibaba/wisp

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/165