### PR TITLE
[Backport] 8273612: Fix for JDK-8272873 causes timeout in running some tests with -Xcomp

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -894,6 +894,10 @@ bool CompilationPolicy::is_method_profiled(const methodHandle& method) {
 
 // Determine is a method is mature.
 bool CompilationPolicy::is_mature(Method* method) {
+  if (Arguments::is_compiler_only()) {
+    // Always report profiles as immature with -Xcomp
+    return false;
+  }
   methodHandle mh(Thread::current(), method);
   MethodData* mdo = method->method_data();
   if (mdo != NULL) {

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsMatureTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsMatureTest.java
@@ -80,9 +80,7 @@ public class IsMatureTest {
                     "Multiple times invoked method should have method data");
             // The method may or may not be mature if it's compiled with limited profile.
             if (compLevel != CompilerWhiteBoxTest.COMP_LEVEL_LIMITED_PROFILE) {
-               /* a method is not mature in Xcomp mode with tiered compilation disabled,
-                 see NonTieredCompPolicy::is_mature */
-               Asserts.assertEQ(isMature, !(Platform.isComp() && !TIERED),
+               Asserts.assertEQ(isMature, !Platform.isComp(),
                        "Unexpected isMature state for multiple times invoked method");
             }
         }

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsMatureVsReprofileTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsMatureVsReprofileTest.java
@@ -83,7 +83,7 @@ public class IsMatureVsReprofileTest {
         isMature = CompilerToVMHelper.isMature(metaspaceMethodData);
         /* a method is not mature for -Xcomp and -Tiered,
            see NonTieredCompPolicy::is_mature */
-        Asserts.assertEQ(!IS_XCOMP || TIERED, isMature,
+        Asserts.assertEQ(!IS_XCOMP, isMature,
                 "Unexpected isMature state for compiled method");
         HotSpotResolvedJavaMethod resolvedMethod
                 = CTVMUtilities.getResolvedMethod(method);
@@ -94,7 +94,7 @@ public class IsMatureVsReprofileTest {
         isMature = CompilerToVMHelper.isMature(metaspaceMethodData);
         Asserts.assertNE(metaspaceMethodData, 0L,
                 "Got null MDO after reprofile");
-        Asserts.assertEQ(TIERED && IS_XCOMP, isMature,
+        Asserts.assertFalse(isMature,
                 "Got unexpected isMature state after reprofiling");
     }
 }


### PR DESCRIPTION
Summary: With tiered it just so happened that profiles are reported as mature with -Xcomp. For some tests this leads to pathological profiles that causes excessive execution time. The fix it make profiles immature when running with -Xcomp.

Test Plan: ci jtreg

Reviewed-by: Kuaiwei, Wangzhuo

Issue: https://github.com/dragonwell-project/dragonwell17/issues/172