### PR TITLE
[Wisp] Remove CoroutineSupport Lock in Java and unnecessary function coroutineMove.

### DIFF
--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -159,9 +159,6 @@ public:
   void do_thread(Thread* thread) {
     if (thread->is_Java_thread() && ! thread->is_Code_cache_sweeper_thread()) {
       thread->as_Java_thread()->nmethods_do(_cl);
-      if (EnableCoroutine) {
-        thread->as_Java_thread()->set_nmethod_traversals(NMethodSweeper::traversal_count());
-      }
     }
   }
 };
@@ -192,6 +189,10 @@ CodeBlobClosure* NMethodSweeper::prepare_mark_active_nmethods() {
   if (PrintMethodFlushing) {
     tty->print_cr("### Sweep: stack traversal %ld", _traversals);
   }
+  return &mark_activation_closure;
+}
+
+CodeBlobClosure* NMethodSweeper::mark_active_closure() {
   return &mark_activation_closure;
 }
 

--- a/src/hotspot/share/runtime/sweeper.hpp
+++ b/src/hotspot/share/runtime/sweeper.hpp
@@ -112,6 +112,7 @@ class NMethodSweeper : public AllStatic {
 #endif
 
   static CodeBlobClosure* prepare_mark_active_nmethods();
+  static CodeBlobClosure* mark_active_closure();
   static void sweeper_loop();
   static bool should_start_aggressive_sweep();
   static void force_sweep();

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -106,6 +106,7 @@
 #include "runtime/stackFrameStream.inline.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/statSampler.hpp"
+#include "runtime/sweeper.hpp"
 #include "runtime/task.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/threadCritical.hpp"
@@ -2179,6 +2180,11 @@ void JavaThread::nmethods_do(CodeBlobClosure* cf) {
       current->compiledMethods_do(cf);
       current = current->next();
     } while (current != _coroutine_list);
+
+    if (NMethodSweeper::mark_active_closure() == cf) {
+      // mark for current thread has been scanned.
+      set_nmethod_traversals(NMethodSweeper::traversal_count());
+    }
   } else {
     if (jvmti_thread_state() != NULL) {
       jvmti_thread_state()->nmethods_do(cf);

--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispTask.java
@@ -335,7 +335,7 @@ public class WispTask implements Comparable<WispTask> {
             // store load barrier is not necessary
         }
         if (terminal == true) {
-            current.carrier.thread.getCoroutineSupport().terminateCoroutine(next.ctx);
+            current.carrier.thread.getCoroutineSupport().terminateCoroutine();
             // should never run here.
             assert false: "should not reach here";
         } else {

--- a/src/java.base/share/classes/java/dyn/CoroutineBase.java
+++ b/src/java.base/share/classes/java/dyn/CoroutineBase.java
@@ -35,8 +35,6 @@ public abstract class CoroutineBase {
 
     boolean finished = false;
 
-    boolean needsUnlock = false;
-
     transient CoroutineSupport threadSupport;
 
     /**
@@ -68,9 +66,6 @@ public abstract class CoroutineBase {
     private final void startInternal() {
         assert threadSupport.getThread() == SharedSecrets.getJavaLangAccess().currentThread0();
         try {
-            // When we symmetricYieldTo a newly created coroutine,
-            // we'll expect the new coroutine release lock as soon as possible
-            threadSupport.beforeResume(this);
             run();
         } catch (Throwable t) {
             if (!(t instanceof CoroutineExitException)) {
@@ -78,10 +73,7 @@ public abstract class CoroutineBase {
             }
         } finally {
             finished = true;
-            // threadSupport is fixed by steal()
-            threadSupport.beforeResume(this);
-
-            threadSupport.terminateCoroutine(null);
+            threadSupport.terminateCoroutine();
         }
         assert threadSupport.getThread() == SharedSecrets.getJavaLangAccess().currentThread0();
     }


### PR DESCRIPTION
[Wisp] Remove CoroutineSupport Lock in Java and unnecessary function coroutineMove.

Summary:
In Java17, we protect double linked list of coroutine in C++. So there is no need to use Locker in Java to protect it. And also, function moveCoroutine is unnecessary, so we should remove it. Refine nmethods_do mark active.

Test Plan: all wisp tests

Reviewed-by: yulei

Issue:
https://github.com/dragonwell-project/dragonwell17/issues/189